### PR TITLE
a few changes towards tensorflow 2 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,38 +1,11 @@
-# absl-py==0.7.1  # only an indirect dependency through tensorflow & tf-slim
-# astor==0.8.0  # only an indirect dependency through tensorflow
-# audioread==2.1.8  # only an indirect dependency through librosa
-# cffi==1.12.3  # only an indirect dependency through soundfile
-# cycler==0.10.0  # only an indirect dependency through scikit-image & matplotlib
-# decorator==4.4.0  # only an indirect dependency through librosa, scikit-image & pescador
-# gast==0.2.2  # only an indirect dependency through tensorflow
-# google-pasta==0.1.7  # only an indirect dependency through tensorflow
-# grpcio==1.22.0  # only an indirect dependency through tensorflow & tensorboard
-# h5py==2.9.0  # only an indirect dependency through tensorflow
 joblib==0.13.2  # also a dependency of librosa, pescador, scikit-learn
-# Keras-Applications==1.0.8  # only an indirect dependency through tensorflow
-# Keras-Preprocessing==1.1.0  # only an indirect dependency through tensorflow
-# kiwisolver==1.1.0  # only an indirect dependency through scikit-image
 librosa==0.7.0
-# llvmlite==0.29.0  # only an indirect dependency through numba (a dependency of librosa)
-# Markdown==3.1.1  # only an indirect dependency through tensorboard
-# numba==0.45.1  # only an indirect dependency through librosa & resampy
 numpy==1.16.4 # also a dependency of essentia, essentia-tensorflow, tensorflow, scikit-image, librosa, scikit-learn, scipy
 pescador==2.0.2
-# protobuf==3.9.0  # only an indirect dependency through tensorflow
-# pycparser==2.19  # only an indirect dependency through cffi --> Soundfile --> librosa
-# pyparsing==2.4.2  # only an indirect dependency through matplotlib --> scikit-image
-# python-dateutil==2.8.0  # only an indirect dependency through matplotlib --> scikit-image
-# pyzmq==18.0.2  # only an indirect dependency through pescador
-# resampy==0.2.1  # only an indirect dependency through librosa
 scikit-learn==0.21.3  # also a dependency of librosa
 scipy==1.3.0  # also a dependency of librosa, scikit-image & scikit-learn
-# six==1.12.0  # only an indirect dependency through many other dependencies: essentia, tensorflow, scikit-*
-# SoundFile==0.10.2  # only an indirect dependency through librosa
 tensorflow==1.15.0
-# termcolor==1.1.0  # only an indirect dependency through tensorflow
 tqdm==4.32.2
-# Werkzeug==0.15.5  # only an indirect dependency through tensorflow
-# wrapt==1.11.2  # only an indirect dependency through tensorflow
 pyyaml
 essentia  # TODO: Fix Essentia version once we have a wheel with the required pytools
 scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 essentia  # TODO: Fix Essentia version once we have a wheel with the required pytools
-joblib==0.13.2  # also a dependency of librosa, pescador, scikit-learn
-librosa==0.7.0
-numpy==1.16.4 # also a dependency of essentia, essentia-tensorflow, tensorflow, scikit-image, librosa, scikit-learn, scipy
-pescador==2.0.2
+joblib~=0.13.2  # also a dependency of librosa, pescador, scikit-learn
+librosa~=0.7.0
+numpy~=1.16.4 # also a dependency of essentia, essentia-tensorflow, tensorflow, scikit-image, librosa, scikit-learn, scipy
+pescador~=2.0.2
 pyyaml
 scikit-image
-scikit-learn==0.21.3  # also a dependency of librosa
-scipy==1.3.0  # also a dependency of librosa, scikit-image & scikit-learn
+scikit-learn~=0.21.3  # also a dependency of librosa
+scipy~=1.3.0  # also a dependency of librosa, scikit-image & scikit-learn
 tensorflow>=1.15.0,<3.0
 tf-slim
-tqdm==4.32.2
+tqdm~=4.32.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,39 +1,39 @@
-absl-py==0.7.1
-astor==0.8.0
-audioread==2.1.8
-cffi==1.12.3
-cycler==0.10.0
-decorator==4.4.0
-gast==0.2.2
-google-pasta==0.1.7
-grpcio==1.22.0
-h5py==2.9.0
-joblib==0.13.2
-Keras-Applications==1.0.8
-Keras-Preprocessing==1.1.0
-kiwisolver==1.1.0
+# absl-py==0.7.1  # only an indirect dependency through tensorflow & tf-slim
+# astor==0.8.0  # only an indirect dependency through tensorflow
+# audioread==2.1.8  # only an indirect dependency through librosa
+# cffi==1.12.3  # only an indirect dependency through soundfile
+# cycler==0.10.0  # only an indirect dependency through scikit-image & matplotlib
+# decorator==4.4.0  # only an indirect dependency through librosa, scikit-image & pescador
+# gast==0.2.2  # only an indirect dependency through tensorflow
+# google-pasta==0.1.7  # only an indirect dependency through tensorflow
+# grpcio==1.22.0  # only an indirect dependency through tensorflow & tensorboard
+# h5py==2.9.0  # only an indirect dependency through tensorflow
+joblib==0.13.2  # also a dependency of librosa, pescador, scikit-learn
+# Keras-Applications==1.0.8  # only an indirect dependency through tensorflow
+# Keras-Preprocessing==1.1.0  # only an indirect dependency through tensorflow
+# kiwisolver==1.1.0  # only an indirect dependency through scikit-image
 librosa==0.7.0
-llvmlite==0.29.0
-Markdown==3.1.1
-numba==0.45.1
-numpy==1.16.4
+# llvmlite==0.29.0  # only an indirect dependency through numba (a dependency of librosa)
+# Markdown==3.1.1  # only an indirect dependency through tensorboard
+# numba==0.45.1  # only an indirect dependency through librosa & resampy
+numpy==1.16.4 # also a dependency of essentia, essentia-tensorflow, tensorflow, scikit-image, librosa, scikit-learn, scipy
 pescador==2.0.2
-protobuf==3.9.0
-pycparser==2.19
-pyparsing==2.4.2
-python-dateutil==2.8.0
-pyzmq==18.0.2
-resampy==0.2.1
-scikit-learn==0.21.3
-scipy==1.3.0
-six==1.12.0
-SoundFile==0.10.2
+# protobuf==3.9.0  # only an indirect dependency through tensorflow
+# pycparser==2.19  # only an indirect dependency through cffi --> Soundfile --> librosa
+# pyparsing==2.4.2  # only an indirect dependency through matplotlib --> scikit-image
+# python-dateutil==2.8.0  # only an indirect dependency through matplotlib --> scikit-image
+# pyzmq==18.0.2  # only an indirect dependency through pescador
+# resampy==0.2.1  # only an indirect dependency through librosa
+scikit-learn==0.21.3  # also a dependency of librosa
+scipy==1.3.0  # also a dependency of librosa, scikit-image & scikit-learn
+# six==1.12.0  # only an indirect dependency through many other dependencies: essentia, tensorflow, scikit-*
+# SoundFile==0.10.2  # only an indirect dependency through librosa
 tensorflow==1.15.0
-termcolor==1.1.0
+# termcolor==1.1.0  # only an indirect dependency through tensorflow
 tqdm==4.32.2
-Werkzeug==0.15.5
-wrapt==1.11.2
+# Werkzeug==0.15.5  # only an indirect dependency through tensorflow
+# wrapt==1.11.2  # only an indirect dependency through tensorflow
 pyyaml
-essentia  # TODO: Fix Essentia version once we havea a wheel with the required pytools
+essentia  # TODO: Fix Essentia version once we have a wheel with the required pytools
 scikit-image
 tf-slim

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pyyaml
 scikit-image
 scikit-learn==0.21.3  # also a dependency of librosa
 scipy==1.3.0  # also a dependency of librosa, scikit-image & scikit-learn
-tensorflow==1.15.0
+tensorflow>=1.15.0,<3.0
 tf-slim
 tqdm==4.32.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
+essentia  # TODO: Fix Essentia version once we have a wheel with the required pytools
 joblib==0.13.2  # also a dependency of librosa, pescador, scikit-learn
 librosa==0.7.0
 numpy==1.16.4 # also a dependency of essentia, essentia-tensorflow, tensorflow, scikit-image, librosa, scikit-learn, scipy
 pescador==2.0.2
+pyyaml
+scikit-image
 scikit-learn==0.21.3  # also a dependency of librosa
 scipy==1.3.0  # also a dependency of librosa, scikit-image & scikit-learn
 tensorflow==1.15.0
-tqdm==4.32.2
-pyyaml
-essentia  # TODO: Fix Essentia version once we have a wheel with the required pytools
-scikit-image
 tf-slim
+tqdm==4.32.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ wrapt==1.11.2
 pyyaml
 essentia  # TODO: Fix Essentia version once we havea a wheel with the required pytools
 scikit-image
+tf-slim

--- a/src/batch_train.py
+++ b/src/batch_train.py
@@ -2,27 +2,24 @@ import argparse
 import json
 import os
 import time
-import random
-import pescador
-import numpy as np
-import tensorflow as tf
-from tensorflow.keras.backend import binary_crossentropy
-
-import shared
-import pickle
-from tensorflow.python.framework import ops
-import yaml
 from argparse import Namespace
+
+import numpy as np
+import pescador
+import shared
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+import yaml
 
 config_file = Namespace(**yaml.load(open('config_file.yaml'), Loader=yaml.SafeLoader))
 
 
 def tf_define_model_and_cost(config):
     # tensorflow: define the model
-    with tf.name_scope('model'):
-        x = tf.compat.v1.placeholder(tf.float32, [None, config['xInput'], config['yInput']])
-        y_ = tf.compat.v1.placeholder(tf.float32, [None, config['num_classes_dataset']])
-        is_train = tf.compat.v1.placeholder(tf.bool)
+    with tf.name_scope("model"):
+        x = tf.placeholder(tf.float32, [None, config["xInput"], config["yInput"]])
+        y_ = tf.placeholder(tf.float32, [None, config["num_classes_dataset"]])
+        is_train = tf.placeholder(tf.bool)
 
         # choose between transfer learning or fully trainable models
         if config['load_model'] is not None:
@@ -162,9 +159,9 @@ if __name__ == '__main__':
     saver = tf.train.Saver()
     if config['load_model'] is not None:  # restore model weights from previously saved model
         if config['model_number'] == 20 or 11 or 15:
-            saver = tf.compat.v1.train.Saver(var_list=model_vars[:-4])
+            saver = tf.train.Saver(var_list=model_vars[:-4])
         else:
-            saver = tf.compat.v1.train.Saver(var_list=model_vars[:-2])
+            saver = tf.train.Saver(var_list=model_vars[:-2])
         saver.restore(sess, config['load_model'])  # end with /!
         print('Pre-trained model loaded!')
 
@@ -172,7 +169,7 @@ if __name__ == '__main__':
 
     # After restoring make it aware of the rest of the variables
     # saver.var_list = model_vars
-    saver = tf.compat.v1.train.Saver()
+    saver = tf.train.Saver()
 
     # writing headers of the train_log.tsv
     fy = open(model_folder + 'train_log.tsv', 'a')

--- a/src/classification_heads.py
+++ b/src/classification_heads.py
@@ -10,7 +10,7 @@ def regular(y, config):
         # VGGish models already defined their classification head
         return y
     else:
-        initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config["seed"])
+        initializer = tf.initializers.variance_scaling(scale=2.0, seed=config["seed"])
         return tf.layers.dense(
             inputs=y,
             activation=None,
@@ -27,7 +27,7 @@ def adversarial_type_a(y, config):
     """
     d_ = tf.placeholder(tf.float32, [None, config["discriminator_dimensions"]])
 
-    initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config["seed"])
+    initializer = tf.initializers.variance_scaling(scale=2.0, seed=config["seed"])
     y = tf.layers.dense(
         inputs=y,
         activation=None,
@@ -76,7 +76,7 @@ def adversarial_type_b(y, config):
     # Gradient projection layer
     y, d = gradient_projection(shared_dense, flipped)
 
-    initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config["seed"])
+    initializer = tf.initializers.variance_scaling(scale=2.0, seed=config["seed"])
     y = tf.layers.dense(
         inputs=tf.reshape(y, [-1, config["coupling_layer_units"]]),
         activation=None,
@@ -105,7 +105,7 @@ def adversarial_grl(y, config):
     lam = tf.placeholder(tf.float32)
     flipped = flip_gradient(coupling_layer, lam)
 
-    initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config["seed"])
+    initializer = tf.initializers.variance_scaling(scale=2.0, seed=config["seed"])
     y = tf.layers.dense(
         inputs=coupling_layer,
         activation=tf.nn.relu,

--- a/src/classification_heads.py
+++ b/src/classification_heads.py
@@ -1,31 +1,40 @@
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+
 from flip_gradient import flip_gradient
 from gradient_projection import gradient_projection
 
 
 def regular(y, config):
-    if config['model_number'] == 20:
-        # VGGish models already defined their classificaton head
+    if config["model_number"] == 20:
+        # VGGish models already defined their classification head
         return y
     else:
-        return tf.compat.v1.layers.dense(inputs=y,
-                                    activation=None,
-                                    units=config['num_classes_dataset'],
-                                    kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+        initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config["seed"])
+        return tf.layers.dense(
+            inputs=y,
+            activation=None,
+            units=config["num_classes_dataset"],
+            kernel_initializer=initializer,
+        )
+
 
 def adversarial_type_a(y, config):
-    """ type A adversarial heads
-    Discriminator conected to the classifier.
+    """type A adversarial heads
+    Discriminator connected to the classifier.
     This case is not contemplated for our experiments as is not possible
     to infer the complex discriminator task from the classification output.
     """
-    d_ = tf.compat.v1.placeholder(tf.float32, [None, config['discriminator_dimensions']])
+    d_ = tf.placeholder(tf.float32, [None, config["discriminator_dimensions"]])
 
-    y = tf.compat.v1.layers.dense(inputs=y,
+    initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config["seed"])
+    y = tf.layers.dense(
+        inputs=y,
         activation=None,
-        units=config['num_classes_dataset'],
-        kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    
+        units=config["num_classes_dataset"],
+        kernel_initializer=initializer,
+    )
+
     # RevGrad layer
     lam = tf.placeholder(tf.float32)
     flipped = flip_gradient(y, lam)
@@ -36,24 +45,29 @@ def adversarial_type_a(y, config):
     y = tf.reshape(y, [-1, config['num_classes_dataset']])
     d = tf.reshape(d, [-1, config['num_classes_dataset']])
 
-    d = tf.compat.v1.layers.dense(inputs=d,
-                units=config['coupling_layer_units'],
-                activation=tf.nn.relu,
-                kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+    d = tf.layers.dense(
+        inputs=d,
+        units=config["coupling_layer_units"],
+        activation=tf.nn.relu,
+        kernel_initializer=initializer,
+    )
 
-    d = tf.compat.v1.layers.dense(inputs=d,
+    d = tf.layers.dense(
+        inputs=d,
         activation=None,
-        units=config['discriminator_dimensions'],
-        kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+        units=config["discriminator_dimensions"],
+        kernel_initializer=initializer,
+    )
     return y, d, d_
 
+
 def adversarial_type_b(y, config):
-    """ type B adversarial heads
-    A common layer conected to the feature extractor with 2 heads,
+    """type B adversarial heads
+    A common layer connected to the feature extractor with 2 heads,
     one for the classification and other for the discrimination task.
     """
     shared_dense = y
-    d_ = tf.compat.v1.placeholder(tf.float32, [None, config['discriminator_dimensions']])
+    d_ = tf.placeholder(tf.float32, [None, config["discriminator_dimensions"]])
 
     # RevGrad layer
     lam = tf.placeholder(tf.float32)
@@ -62,46 +76,61 @@ def adversarial_type_b(y, config):
     # Gradient projection layer
     y, d = gradient_projection(shared_dense, flipped)
 
-    y = tf.compat.v1.layers.dense(inputs=tf.reshape(y, [-1, config['coupling_layer_units']]),
-                                    activation=None,
-                                    units=config['num_classes_dataset'],
-                                    kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+    initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config["seed"])
+    y = tf.layers.dense(
+        inputs=tf.reshape(y, [-1, config["coupling_layer_units"]]),
+        activation=None,
+        units=config["num_classes_dataset"],
+        kernel_initializer=initializer,
+    )
 
-    d = tf.compat.v1.layers.dense(inputs=tf.reshape(d, [-1, config['coupling_layer_units']]),
-                        activation=None,
-                        units=config['discriminator_dimensions'],
-                        kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+    d = tf.layers.dense(
+        inputs=tf.reshape(d, [-1, config["coupling_layer_units"]]),
+        activation=None,
+        units=config["discriminator_dimensions"],
+        kernel_initializer=initializer,
+    )
     return y, d, d_
 
+
 def adversarial_grl(y, config):
-    """ Adversarial heads with Gradient reversal layer
-    A common layer conected to the feature extractor with 2 heads,
+    """Adversarial heads with Gradient reversal layer
+    A common layer connected to the feature extractor with 2 heads,
     one for the classification and other for the discrimination task.
     """
     coupling_layer = y
-    d_ = tf.compat.v1.placeholder(tf.float32, [None, config['discriminator_dimensions']])
+    d_ = tf.placeholder(tf.float32, [None, config["discriminator_dimensions"]])
 
     # RevGrad layer
     lam = tf.placeholder(tf.float32)
     flipped = flip_gradient(coupling_layer, lam)
 
-    y = tf.compat.v1.layers.dense(inputs=coupling_layer,
-                                  activation=tf.nn.relu,
-                                  units=config['coupling_layer_units'],
-                                  kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+    initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config["seed"])
+    y = tf.layers.dense(
+        inputs=coupling_layer,
+        activation=tf.nn.relu,
+        units=config["coupling_layer_units"],
+        kernel_initializer=initializer,
+    )
 
-    y = tf.compat.v1.layers.dense(inputs=y,
-                                  activation=None,
-                                  units=config['num_classes_dataset'],
-                                  kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+    y = tf.layers.dense(
+        inputs=y,
+        activation=None,
+        units=config["num_classes_dataset"],
+        kernel_initializer=initializer,
+    )
 
-    d = tf.compat.v1.layers.dense(inputs=flipped,
-                                  activation=tf.nn.relu,
-                                  units=config['coupling_layer_units'],
-                                  kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+    d = tf.layers.dense(
+        inputs=flipped,
+        activation=tf.nn.relu,
+        units=config["coupling_layer_units"],
+        kernel_initializer=initializer,
+    )
 
-    d = tf.compat.v1.layers.dense(inputs=d,
-                                  activation=None,
-                                  units=config['discriminator_dimensions'],
-                                  kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+    d = tf.layers.dense(
+        inputs=d,
+        activation=None,
+        units=config["discriminator_dimensions"],
+        kernel_initializer=initializer,
+    )
     return y, d, d_, lam

--- a/src/classification_heads.py
+++ b/src/classification_heads.py
@@ -10,12 +10,11 @@ def regular(y, config):
         # VGGish models already defined their classification head
         return y
     else:
-        initializer = tf.initializers.variance_scaling(scale=2.0, seed=config["seed"])
         return tf.layers.dense(
             inputs=y,
             activation=None,
             units=config["num_classes_dataset"],
-            kernel_initializer=initializer,
+            kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
         )
 
 

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -3,7 +3,8 @@ import json
 import pescador
 import shared, train
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 from tqdm import tqdm
 import yaml
 from argparse import Namespace

--- a/src/models.py
+++ b/src/models.py
@@ -1,11 +1,13 @@
-import tensorflow as tf
-import models_frontend as frontend
-import models_midend as midend
 import models_backend as backend
 import models_baselines
+import models_frontend as frontend
+import models_midend as midend
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+
 
 # disabling deprecation warnings (caused by change from tensorflow 1.x to 2.x)
-tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
+tf.logging.set_verbosity(tf.logging.ERROR)
 
 def model_number(x, is_training, config):
     if config['load_model'] is not None:

--- a/src/models_backend.py
+++ b/src/models_backend.py
@@ -62,8 +62,8 @@ def temporal_pooling(feature_map, is_training, num_classes_dataset, num_units_ba
         tmp_pool = tf.concat([max_pool, avg_pool], 1)
 
     print('Temporal pooling: ' + str(tmp_pool.shape))
-    # dense layer with droupout
-    flat_pool = tf.contrib.layers.flatten(tmp_pool)
+    # dense layer with dropout
+    flat_pool = tf.layers.flatten(tmp_pool)
     flat_pool = tf.layers.batch_normalization(flat_pool, training=is_training, trainable=trainable)
     flat_pool_dropout = tf.layers.dropout(flat_pool, rate=0.5, training=is_training, seed=config["seed"])
     dense = tf.layers.dense(

--- a/src/models_backend.py
+++ b/src/models_backend.py
@@ -1,5 +1,6 @@
-import tensorflow as tf
 import numpy as np
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 
 def temporal_pooling(feature_map, is_training, num_classes_dataset, num_units_backend, config, type, return_penultimate=False, trainable=True):
@@ -22,15 +23,21 @@ def temporal_pooling(feature_map, is_training, num_classes_dataset, num_units_ba
             feature_map = tf.add(feature_map, pos_embedding)
 
         # compute attention
-        context=3
-        padded = tf.pad(feature_map, [[0, 0], [int(context/2), int(context/2)], [0, 0]], "CONSTANT")
-        frames_attention = tf.compat.v1.layers.conv1d(inputs=padded,
-                             filters=padded.shape[2],
-                             kernel_size=context,
-                             padding="valid",
-                             activation=None,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-        softmax_layer = tf.nn.softmax(frames_attention,axis=1)
+        context = 3
+        padded = tf.pad(
+            feature_map,
+            [[0, 0], [int(context / 2), int(context / 2)], [0, 0]],
+            "CONSTANT",
+        )
+        frames_attention = tf.layers.conv1d(
+            inputs=padded,
+            filters=padded.shape[2],
+            kernel_size=context,
+            padding="valid",
+            activation=None,
+            kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+        )
+        softmax_layer = tf.nn.softmax(frames_attention, axis=1)
 
         # apply attention
         weighted = tf.multiply(softmax_layer, feature_map)
@@ -57,30 +64,36 @@ def temporal_pooling(feature_map, is_training, num_classes_dataset, num_units_ba
     print('Temporal pooling: ' + str(tmp_pool.shape))
     # dense layer with droupout
     flat_pool = tf.contrib.layers.flatten(tmp_pool)
-    flat_pool = tf.compat.v1.layers.batch_normalization(flat_pool, training=is_training, trainable=trainable)
-    flat_pool_dropout = tf.layers.dropout(flat_pool, rate=0.5, training=is_training, seed=config['seed'])
-    dense = tf.compat.v1.layers.dense(inputs=flat_pool_dropout,
-                            units=num_units_backend,
-                            activation=tf.nn.relu,
-                            kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']),
-                            trainable=trainable)
-    bn_dense = tf.compat.v1.layers.batch_normalization(dense, training=is_training, trainable=trainable)
-    dense_dropout = tf.compat.v1.layers.dropout(bn_dense, rate=0.5, training=is_training, seed=config['seed'])
-
+    flat_pool = tf.layers.batch_normalization(flat_pool, training=is_training, trainable=trainable)
+    flat_pool_dropout = tf.layers.dropout(flat_pool, rate=0.5, training=is_training, seed=config["seed"])
+    dense = tf.layers.dense(
+        inputs=flat_pool_dropout,
+        units=num_units_backend,
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+        trainable=trainable,
+    )
+    bn_dense = tf.layers.batch_normalization(dense, training=is_training, trainable=trainable)
+    dense_dropout = tf.layers.dropout(bn_dense, rate=0.5, training=is_training, seed=config["seed"])
 
     # Smaller dense layer shared betwen tasks/
-    shared_dense = tf.compat.v1.layers.dense(inputs=dense_dropout,
+    shared_dense = tf.layers.dense(
+        inputs=dense_dropout,
         units=num_units_backend // 2,
         activation=None,
-        kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
 
     if return_penultimate:
         return shared_dense
     else:
-        return tf.compat.v1.layers.dense(inputs=shared_dense,
-                           activation=None,
-                           units=num_classes_dataset,
-                           kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+        return tf.layers.dense(
+            inputs=shared_dense,
+            activation=None,
+            units=num_classes_dataset,
+            kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+        )
+
 
 def positional_encoding(feature_map_size):
     _, T, num_units = feature_map_size

--- a/src/models_baselines.py
+++ b/src/models_baselines.py
@@ -1,133 +1,156 @@
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 
 def perceptron(x, is_training, config):
-    x = tf.compat.v1.squeeze(x, axis=[1])
-    # x = tf.compat.v1.layers.dropout(x, rate=0.5, training=is_training)
-    # x = tf.compat.v1.layers.batch_normalization(x, training=is_training)
-    return tf.compat.v1.layers.dense(inputs=x,
-                                     activation=tf.nn.relu,
-                                     units=config['coupling_layer_units'],
-                                     kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+    x = tf.squeeze(x, axis=[1])
+    # x = tf.layers.dropout(x, rate=0.5, training=is_training)
+    # x = tf.layers.batch_normalization(x, training=is_training)
+    return tf.layers.dense(
+        inputs=x,
+        activation=tf.nn.relu,
+        units=config["coupling_layer_units"],
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
 
 
 def dieleman(x, is_training, config):
     print('Input: ' + str(x.get_shape))
     input_layer = tf.expand_dims(x, 3)
-    bn_input = tf.compat.v1.layers.batch_normalization(input_layer, training=is_training)
+    bn_input = tf.layers.batch_normalization(input_layer, training=is_training)
 
-    conv1 = tf.compat.v1.layers.conv2d(inputs=bn_input, 
-    	                     filters=32, 
-    	                     kernel_size=[8, config['yInput']],
-    	                     padding="valid", 
-    	                     activation=tf.nn.relu, 
-    	                     name='1cnnOut', 
-    	                     kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    pool1 = tf.compat.v1.layers.max_pooling2d(inputs=conv1, pool_size=[4, 1], strides=[4, 1], name='1-pool')
+    conv1 = tf.layers.conv2d(
+        inputs=bn_input,
+        filters=32,
+        kernel_size=[8, config["yInput"]],
+        padding="valid",
+        activation=tf.nn.relu,
+        name="1cnnOut",
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    pool1 = tf.layers.max_pooling2d(inputs=conv1, pool_size=[4, 1], strides=[4, 1], name="1-pool")
     pool1_rs = tf.reshape(pool1, [-1, int(pool1.shape[1]), int(pool1.shape[3]), 1])
     print('\t\t' + str(pool1_rs.get_shape))
 
-    conv2 = tf.compat.v1.layers.conv2d(inputs=pool1_rs, 
-    	                     filters=32, 
-    	                     kernel_size=[8, pool1_rs.shape[2]], 
-    	                     padding="valid", 
-    	                     activation=tf.nn.relu, 
-    	                     name='2cnnOut', 
-    	                     kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    pool2 = tf.compat.v1.layers.max_pooling2d(inputs=conv2, pool_size=[4, 1], strides=[4, 1], name='2-pool')
-    flat_pool2 = tf.reshape(pool2,[-1,int(pool2.shape[1]*pool2.shape[2]*pool2.shape[3])]) # flatten
-    print('\t\t' + str(flat_pool2.shape))
+    conv2 = tf.layers.conv2d(
+        inputs=pool1_rs,
+        filters=32,
+        kernel_size=[8, pool1_rs.shape[2]],
+        padding="valid",
+        activation=tf.nn.relu,
+        name="2cnnOut",
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    pool2 = tf.layers.max_pooling2d(inputs=conv2, pool_size=[4, 1], strides=[4, 1], name="2-pool")
+    flat_pool2 = tf.reshape(pool2, [-1, int(pool2.shape[1] * pool2.shape[2] * pool2.shape[3])])  # flatten
+    print("\t\t" + str(flat_pool2.shape))
 
-    dense = tf.compat.v1.layers.dense(inputs=flat_pool2, 
-    	                    activation=tf.nn.relu, 
-    	                    units=100, 
-                            kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    output = tf.compat.v1.layers.dense(inputs=dense, 
-    	                   activation=None, 
-    	                   units=config['num_classes_dataset'],
-    	                   kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    print('output: ' + str(output.get_shape))
-    return output 
-    
-    
+    dense = tf.layers.dense(
+        inputs=flat_pool2,
+        activation=tf.nn.relu,
+        units=100,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    output = tf.layers.dense(
+        inputs=dense,
+        activation=None,
+        units=config["num_classes_dataset"],
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    print("output: " + str(output.get_shape))
+    return output
+
+
 def vgg(x, is_training, config, num_filters=32):
     print('Input: ' + str(x.get_shape))
     input_layer = tf.expand_dims(x, 3)
-    bn_input = tf.compat.v1.layers.batch_normalization(input_layer, training=is_training)
+    bn_input = tf.layers.batch_normalization(input_layer, training=is_training)
 
-    conv1 = tf.compat.v1.layers.conv2d(inputs=bn_input,
-                             filters=num_filters,
-                             kernel_size=[3, 3],
-                             padding='same',
-                             activation=tf.nn.relu,
-                             name='1CNN',
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv1 = tf.compat.v1.layers.batch_normalization(conv1, training=is_training)
-    pool1 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv1, pool_size=[4, 1], strides=[2, 2])
+    conv1 = tf.layers.conv2d(
+        inputs=bn_input,
+        filters=num_filters,
+        kernel_size=[3, 3],
+        padding="same",
+        activation=tf.nn.relu,
+        name="1CNN",
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv1 = tf.layers.batch_normalization(conv1, training=is_training)
+    pool1 = tf.layers.max_pooling2d(inputs=bn_conv1, pool_size=[4, 1], strides=[2, 2])
     print('pool1: ' + str(pool1.get_shape))
 
-    do_pool1 = tf.compat.v1.layers.dropout(pool1, rate=0.25, training=is_training, seed=config['seed'])
-    conv2 = tf.compat.v1.layers.conv2d(inputs=do_pool1,
-                             filters=num_filters,
-                             kernel_size=[3, 3],
-                             padding='same',
-                             activation=tf.nn.relu,
-                             name='2CNN',
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv2 = tf.compat.v1.layers.batch_normalization(conv2, training=is_training)
-    pool2 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv2, pool_size=[2, 2], strides=[2, 2])
+    do_pool1 = tf.layers.dropout(pool1, rate=0.25, training=is_training, seed=config["seed"])
+    conv2 = tf.layers.conv2d(
+        inputs=do_pool1,
+        filters=num_filters,
+        kernel_size=[3, 3],
+        padding="same",
+        activation=tf.nn.relu,
+        name="2CNN",
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv2 = tf.layers.batch_normalization(conv2, training=is_training)
+    pool2 = tf.layers.max_pooling2d(inputs=bn_conv2, pool_size=[2, 2], strides=[2, 2])
     print('pool2: ' + str(pool2.get_shape))
 
-    do_pool2 = tf.compat.v1.layers.dropout(pool2, rate=0.25, training=is_training, seed=config['seed'])
-    conv3 = tf.compat.v1.layers.conv2d(inputs=do_pool2,
-                             filters=num_filters,
-                             kernel_size=[3, 3],
-                             padding='same',
-                             activation=tf.nn.relu,
-                             name='3CNN',
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv3 = tf.compat.v1.layers.batch_normalization(conv3, training=is_training)
-    pool3 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv3, pool_size=[2, 2], strides=[2, 2])
+    do_pool2 = tf.layers.dropout(pool2, rate=0.25, training=is_training, seed=config["seed"])
+    conv3 = tf.layers.conv2d(
+        inputs=do_pool2,
+        filters=num_filters,
+        kernel_size=[3, 3],
+        padding="same",
+        activation=tf.nn.relu,
+        name="3CNN",
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv3 = tf.layers.batch_normalization(conv3, training=is_training)
+    pool3 = tf.layers.max_pooling2d(inputs=bn_conv3, pool_size=[2, 2], strides=[2, 2])
     print('pool3: ' + str(pool3.get_shape))
 
-    do_pool3 = tf.layers.dropout(pool3, rate=0.25, training=is_training, seed=config['seed'])
-    conv4 = tf.layers.conv2d(inputs=do_pool3,
-                             filters=num_filters,
-                             kernel_size=[3, 3],
-                             padding='same',
-                             activation=tf.nn.relu,
-                             name='4CNN',
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv4 = tf.compat.v1.layers.batch_normalization(conv4, training=is_training)
-    pool4 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv4, pool_size=[2, 2], strides=[2, 2])
+    do_pool3 = tf.layers.dropout(pool3, rate=0.25, training=is_training, seed=config["seed"])
+    conv4 = tf.layers.conv2d(
+        inputs=do_pool3,
+        filters=num_filters,
+        kernel_size=[3, 3],
+        padding="same",
+        activation=tf.nn.relu,
+        name="4CNN",
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv4 = tf.layers.batch_normalization(conv4, training=is_training)
+    pool4 = tf.layers.max_pooling2d(inputs=bn_conv4, pool_size=[2, 2], strides=[2, 2])
     print('pool4: ' + str(pool4.get_shape))
 
-    do_pool4 = tf.compat.v1.layers.dropout(pool4, rate=0.25, training=is_training, seed=config['seed'])
-    conv5 = tf.compat.v1.layers.conv2d(inputs=do_pool4, 
-                             filters=num_filters, 
-                             kernel_size=[3, 3], 
-                             padding='same', 
-                             activation=tf.nn.relu,
-                             name='5CNN', 
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv5 = tf.compat.v1.layers.batch_normalization(conv5, training=is_training)
+    do_pool4 = tf.layers.dropout(pool4, rate=0.25, training=is_training, seed=config["seed"])
+    conv5 = tf.layers.conv2d(
+        inputs=do_pool4,
+        filters=num_filters,
+        kernel_size=[3, 3],
+        padding="same",
+        activation=tf.nn.relu,
+        name="5CNN",
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv5 = tf.layers.batch_normalization(conv5, training=is_training)
     pool5 = tf.layers.max_pooling2d(inputs=bn_conv5, pool_size=[4, 4], strides=[4, 4])
     print('pool5: ' + str(pool5.get_shape))
 
     flat_pool5 = tf.contrib.layers.flatten(pool5)
-    do_pool5 = tf.compat.v1.layers.dropout(flat_pool5, rate=0.5, training=is_training, seed=config['seed'])
-    output = tf.compat.v1.layers.dense(inputs=do_pool5,
-                            activation=None,
-                            units=config['num_classes_dataset'],
-                            kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    print('output: ' + str(output.get_shape))    
-    return output    
+    do_pool5 = tf.layers.dropout(flat_pool5, rate=0.5, training=is_training, seed=config["seed"])
+    output = tf.layers.dense(
+        inputs=do_pool5,
+        activation=None,
+        units=config["num_classes_dataset"],
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    print("output: " + str(output.get_shape))
+    return output
 
 
 def timbre(x, is_training, config, num_filt=1):
     print('Input: ' + str(x.get_shape))
     expanded_layer = tf.expand_dims(x, 3)
-    input_layer = tf.compat.v1.layers.batch_normalization(expanded_layer, training=is_training)
+    input_layer = tf.layers.batch_normalization(expanded_layer, training=is_training)
     
     # FRONT END
     
@@ -138,157 +161,165 @@ def timbre(x, is_training, config, num_filt=1):
     input_pad_3 = tf.pad(input_layer, [[0, 0], [1, 1], [0, 0], [0, 0]], "CONSTANT")
 
     # [TIMBRE] filter shape 1: 7x0.8f
-    conv1 = tf.compat.v1.layers.conv2d(inputs=input_pad_7,
-                             filters=3*num_filt,
-                             kernel_size=[7, int(0.8 * config['yInput'])],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv1 = tf.compat.v1.layers.batch_normalization(conv1, training=is_training)
-    pool1 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv1,
-                                    pool_size=[1, bn_conv1.shape[2]],
-                                    strides=[1, bn_conv1.shape[2]])
+    conv1 = tf.layers.conv2d(
+        inputs=input_pad_7,
+        filters=3 * num_filt,
+        kernel_size=[7, int(0.8 * config["yInput"])],
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv1 = tf.layers.batch_normalization(conv1, training=is_training)
+    pool1 = tf.layers.max_pooling2d(inputs=bn_conv1, pool_size=[1, bn_conv1.shape[2]], strides=[1, bn_conv1.shape[2]])
     p1 = tf.squeeze(pool1, [2])
 
     # [TIMBRE] filter shape 2: 5x0.8f
-    conv2 = tf.compat.v1.layers.conv2d(inputs=input_pad_5,
-                             filters=3*num_filt,
-                             kernel_size=[5, int(0.8 * config['yInput'])],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv2 = tf.compat.v1.layers.batch_normalization(conv2, training=is_training)
-    pool2 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv2,
-                                    pool_size=[1, bn_conv2.shape[2]],
-                                    strides=[1, bn_conv2.shape[2]])
-    p2 = tf.squeeze(pool2, [2])    
+    conv2 = tf.layers.conv2d(
+        inputs=input_pad_5,
+        filters=3 * num_filt,
+        kernel_size=[5, int(0.8 * config["yInput"])],
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv2 = tf.layers.batch_normalization(conv2, training=is_training)
+    pool2 = tf.layers.max_pooling2d(inputs=bn_conv2, pool_size=[1, bn_conv2.shape[2]], strides=[1, bn_conv2.shape[2]])
+    p2 = tf.squeeze(pool2, [2])
 
     # [TIMBRE] filter shape 3: 3x0.8f
-    conv3 = tf.compat.v1.layers.conv2d(inputs=input_pad_3, 
-                             filters=6*num_filt,
-                             kernel_size=[3, int(0.8 * config['yInput'])],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv3 = tf.compat.v1.layers.batch_normalization(conv3, training=is_training)
-    pool3 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv3,
-                                    pool_size=[1, bn_conv3.shape[2]],
-                                    strides=[1, bn_conv3.shape[2]])
+    conv3 = tf.layers.conv2d(
+        inputs=input_pad_3,
+        filters=6 * num_filt,
+        kernel_size=[3, int(0.8 * config["yInput"])],
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv3 = tf.layers.batch_normalization(conv3, training=is_training)
+    pool3 = tf.layers.max_pooling2d(inputs=bn_conv3, pool_size=[1, bn_conv3.shape[2]], strides=[1, bn_conv3.shape[2]])
     p3 = tf.squeeze(pool3, [2])
 
     # [TIMBRE] filter shape 4: 1x0.8f
-    conv4 = tf.compat.v1.layers.conv2d(inputs=input_layer, 
-                             filters=10*num_filt,
-                             kernel_size=[1, int(0.8 * config['yInput'])],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv4 = tf.compat.v1.layers.batch_normalization(conv4, training=is_training)
-    pool4 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv4,
-                                    pool_size=[1, bn_conv4.shape[2]],
-                                    strides=[1, bn_conv4.shape[2]])
+    conv4 = tf.layers.conv2d(
+        inputs=input_layer,
+        filters=10 * num_filt,
+        kernel_size=[1, int(0.8 * config["yInput"])],
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv4 = tf.layers.batch_normalization(conv4, training=is_training)
+    pool4 = tf.layers.max_pooling2d(inputs=bn_conv4, pool_size=[1, bn_conv4.shape[2]], strides=[1, bn_conv4.shape[2]])
     p4 = tf.squeeze(pool4, [2])
 
     # [TIMBRE] filter shape 5: 7x0.6f
-    conv5 = tf.compat.v1.layers.conv2d(inputs=input_pad_7,
-                             filters=5*num_filt,
-                             kernel_size=[7, int(0.6 * config['yInput'])],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv5 = tf.compat.v1.layers.batch_normalization(conv5, training=is_training)
-    pool5 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv5,
-                                    pool_size=[1, bn_conv5.shape[2]],
-                                    strides=[1, bn_conv5.shape[2]])
+    conv5 = tf.layers.conv2d(
+        inputs=input_pad_7,
+        filters=5 * num_filt,
+        kernel_size=[7, int(0.6 * config["yInput"])],
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv5 = tf.layers.batch_normalization(conv5, training=is_training)
+    pool5 = tf.layers.max_pooling2d(inputs=bn_conv5, pool_size=[1, bn_conv5.shape[2]], strides=[1, bn_conv5.shape[2]])
     p5 = tf.squeeze(pool5, [2])
 
     # [TIMBRE] filter shape 6: 5x0.6f
-    conv6 = tf.compat.v1.layers.conv2d(inputs=input_pad_5, 
-                             filters=5*num_filt,
-                             kernel_size=[5, int(0.6 * config['yInput'])],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv6 = tf.compat.v1.layers.batch_normalization(conv6, training=is_training)
-    pool6 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv6, 
-    	                            pool_size=[1, bn_conv6.shape[2]],
-                                    strides=[1, bn_conv6.shape[2]])
-    p6 = tf.squeeze(pool6, [2])    
+    conv6 = tf.layers.conv2d(
+        inputs=input_pad_5,
+        filters=5 * num_filt,
+        kernel_size=[5, int(0.6 * config["yInput"])],
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv6 = tf.layers.batch_normalization(conv6, training=is_training)
+    pool6 = tf.layers.max_pooling2d(inputs=bn_conv6, pool_size=[1, bn_conv6.shape[2]], strides=[1, bn_conv6.shape[2]])
+    p6 = tf.squeeze(pool6, [2])
 
     # [TIMBRE] filter shape 7: 3x0.6f
-    conv7 = tf.compat.v1.layers.conv2d(inputs=input_pad_3, 
-                             filters=10*num_filt,
-                             kernel_size=[3, int(0.6 * config['yInput'])],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv7 = tf.compat.v1.layers.batch_normalization(conv7, training=is_training)
-    pool7 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv7, 
-    	                            pool_size=[1, bn_conv7.shape[2]],
-                                    strides=[1, bn_conv7.shape[2]])
+    conv7 = tf.layers.conv2d(
+        inputs=input_pad_3,
+        filters=10 * num_filt,
+        kernel_size=[3, int(0.6 * config["yInput"])],
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv7 = tf.layers.batch_normalization(conv7, training=is_training)
+    pool7 = tf.layers.max_pooling2d(inputs=bn_conv7, pool_size=[1, bn_conv7.shape[2]], strides=[1, bn_conv7.shape[2]])
     p7 = tf.squeeze(pool7, [2])
 
     # [TIMBRE] filter shape 8: 1x0.6f
-    conv8 = tf.compat.v1.layers.conv2d(inputs=input_layer, 
-                             filters=15*num_filt,
-                             kernel_size=[1, int(0.6 * config['yInput'])], padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv8 = tf.compat.v1.layers.batch_normalization(conv8, training=is_training)
-    pool8 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv8, 
-    	                            pool_size=[1, bn_conv8.shape[2]],
-                                    strides=[1, bn_conv8.shape[2]])
+    conv8 = tf.layers.conv2d(
+        inputs=input_layer,
+        filters=15 * num_filt,
+        kernel_size=[1, int(0.6 * config["yInput"])],
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv8 = tf.layers.batch_normalization(conv8, training=is_training)
+    pool8 = tf.layers.max_pooling2d(inputs=bn_conv8, pool_size=[1, bn_conv8.shape[2]], strides=[1, bn_conv8.shape[2]])
     p8 = tf.squeeze(pool8, [2])
 
     # [TIMBRE] filter shape 9: 7x0.2f
-    conv9 = tf.compat.v1.layers.conv2d(inputs=input_pad_7,
-                             filters=5*num_filt,
-                             kernel_size=[7, int(0.2 * config['yInput'])],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv9 = tf.compat.v1.layers.batch_normalization(conv9, training=is_training)
-    pool9 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv9,
-                                    pool_size=[1, bn_conv9.shape[2]],
-                                    strides=[1, bn_conv9.shape[2]])
+    conv9 = tf.layers.conv2d(
+        inputs=input_pad_7,
+        filters=5 * num_filt,
+        kernel_size=[7, int(0.2 * config["yInput"])],
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv9 = tf.layers.batch_normalization(conv9, training=is_training)
+    pool9 = tf.layers.max_pooling2d(inputs=bn_conv9, pool_size=[1, bn_conv9.shape[2]], strides=[1, bn_conv9.shape[2]])
     p9 = tf.squeeze(pool9, [2])
 
     # [TIMBRE] filter shape 10: 5x0.2f
-    conv10 = tf.compat.v1.layers.conv2d(inputs=input_pad_5, 
-                             filters=5*num_filt,
-                             kernel_size=[5, int(0.2 * config['yInput'])],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv10 = tf.compat.v1.layers.batch_normalization(conv10, training=is_training)
-    pool10 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv10, 
-    	                            pool_size=[1, bn_conv10.shape[2]],
-                                    strides=[1, bn_conv10.shape[2]])
-    p10 = tf.squeeze(pool10, [2])    
+    conv10 = tf.layers.conv2d(
+        inputs=input_pad_5,
+        filters=5 * num_filt,
+        kernel_size=[5, int(0.2 * config["yInput"])],
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv10 = tf.layers.batch_normalization(conv10, training=is_training)
+    pool10 = tf.layers.max_pooling2d(
+        inputs=bn_conv10, pool_size=[1, bn_conv10.shape[2]], strides=[1, bn_conv10.shape[2]]
+    )
+    p10 = tf.squeeze(pool10, [2])
 
     # [TIMBRE] filter shape 11: 3x0.2f
-    conv11 = tf.compat.v1.layers.conv2d(inputs=input_pad_3, 
-                             filters=10*num_filt,
-                             kernel_size=[3, int(0.2 * config['yInput'])],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv11 = tf.compat.v1.layers.batch_normalization(conv11, training=is_training)
-    pool11 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv11, 
-    	                            pool_size=[1, bn_conv11.shape[2]],
-                                    strides=[1, bn_conv11.shape[2]])
+    conv11 = tf.layers.conv2d(
+        inputs=input_pad_3,
+        filters=10 * num_filt,
+        kernel_size=[3, int(0.2 * config["yInput"])],
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv11 = tf.layers.batch_normalization(conv11, training=is_training)
+    pool11 = tf.layers.max_pooling2d(
+        inputs=bn_conv11, pool_size=[1, bn_conv11.shape[2]], strides=[1, bn_conv11.shape[2]]
+    )
     p11 = tf.squeeze(pool11, [2])
 
     # [TIMBRE] filter shape 12: 1x0.2f
-    conv12 = tf.compat.v1.layers.conv2d(inputs=input_layer, 
-                             filters=15*num_filt,
-                             kernel_size=[1, int(0.2 * config['yInput'])], padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv12 = tf.compat.v1.layers.batch_normalization(conv12, training=is_training)
-    pool12 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv12, 
-    	                            pool_size=[1, bn_conv12.shape[2]],
-                                    strides=[1, bn_conv12.shape[2]])
+    conv12 = tf.layers.conv2d(
+        inputs=input_layer,
+        filters=15 * num_filt,
+        kernel_size=[1, int(0.2 * config["yInput"])],
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv12 = tf.layers.batch_normalization(conv12, training=is_training)
+    pool12 = tf.layers.max_pooling2d(
+        inputs=bn_conv12, pool_size=[1, bn_conv12.shape[2]], strides=[1, bn_conv12.shape[2]]
+    )
     p12 = tf.squeeze(pool12, [2])
 
     # concatenate all feature maps
@@ -296,28 +327,31 @@ def timbre(x, is_training, config, num_filt=1):
     out_front_end =  tf.expand_dims(pool, 3)    
     
     # BACK END
-    conv2 = tf.compat.v1.layers.conv2d(inputs=out_front_end, 
-    	                     filters=32, 
-    	                     kernel_size=[8, out_front_end.shape[2]], 
-    	                     padding="valid", 
-    	                     activation=tf.nn.relu, 
-    	                     name='2cnnOut', 
-    	                     kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+    conv2 = tf.layers.conv2d(
+        inputs=out_front_end,
+        filters=32,
+        kernel_size=[8, out_front_end.shape[2]],
+        padding="valid",
+        activation=tf.nn.relu,
+        name="2cnnOut",
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
     print(conv2.get_shape)
-    pool2 = tf.compat.v1.layers.max_pooling2d(inputs=conv2, 
-    	                            pool_size=[4, 1], 
-    	                            strides=[4, 1], 
-    	                            name='2-pool')
+    pool2 = tf.layers.max_pooling2d(inputs=conv2, pool_size=[4, 1], strides=[4, 1], name="2-pool")
     print(pool2.get_shape)
     flat_pool2 = tf.reshape(pool2,[-1,int(pool2.shape[1]*pool2.shape[2]*pool2.shape[3])]) # flatten
     print(flat_pool2.shape)
-    dense = tf.compat.v1.layers.dense(inputs=flat_pool2, 
-    	                    activation=tf.nn.relu, 
-    	                    units=100, 
-                            kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    output = tf.compat.v1.layers.dense(inputs=dense, 
-    	                     activation=None, 
-    	                     units=config['num_classes_dataset'], 
-    	                     kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+    dense = tf.layers.dense(
+        inputs=flat_pool2,
+        activation=tf.nn.relu,
+        units=100,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    output = tf.layers.dense(
+        inputs=dense,
+        activation=None,
+        units=config["num_classes_dataset"],
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
     return output
 

--- a/src/models_baselines.py
+++ b/src/models_baselines.py
@@ -135,7 +135,7 @@ def vgg(x, is_training, config, num_filters=32):
     pool5 = tf.layers.max_pooling2d(inputs=bn_conv5, pool_size=[4, 4], strides=[4, 4])
     print('pool5: ' + str(pool5.get_shape))
 
-    flat_pool5 = tf.contrib.layers.flatten(pool5)
+    flat_pool5 = tf.layers.flatten(pool5)
     do_pool5 = tf.layers.dropout(flat_pool5, rate=0.5, training=is_training, seed=config["seed"])
     output = tf.layers.dense(
         inputs=do_pool5,

--- a/src/models_frontend.py
+++ b/src/models_frontend.py
@@ -1,9 +1,11 @@
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+
 
 def musically_motivated_cnns(x, is_training, yInput, num_filt, config, type, trainable=True):
 
     expanded_layer = tf.expand_dims(x, 3)
-    input_layer = tf.compat.v1.layers.batch_normalization(expanded_layer, training=is_training, trainable=trainable)
+    input_layer = tf.layers.batch_normalization(expanded_layer, training=is_training, trainable=trainable)
 
     input_pad_7 = tf.pad(input_layer, [[0, 0], [3, 3], [0, 0], [0, 0]], "CONSTANT")
 
@@ -62,32 +64,32 @@ def musically_motivated_cnns(x, is_training, yInput, num_filt, config, type, tra
 
 def timbral_block(inputs, filters, kernel_size, is_training, config, padding="valid", activation=tf.nn.relu, trainable=True):
 
-    conv = tf.compat.v1.layers.conv2d(inputs=inputs,
-                            filters=filters,
-                            kernel_size=kernel_size,
-                            padding=padding,
-                            activation=activation,
-                            trainable=trainable,
-                            kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv = tf.compat.v1.layers.batch_normalization(conv, training=is_training, trainable=trainable)
-    pool = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv,
-                                   pool_size=[1, bn_conv.shape[2]],
-                                   strides=[1, bn_conv.shape[2]])
+    conv = tf.layers.conv2d(
+        inputs=inputs,
+        filters=filters,
+        kernel_size=kernel_size,
+        padding=padding,
+        activation=activation,
+        trainable=trainable,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv = tf.layers.batch_normalization(conv, training=is_training, trainable=trainable)
+    pool = tf.layers.max_pooling2d(inputs=bn_conv, pool_size=[1, bn_conv.shape[2]], strides=[1, bn_conv.shape[2]])
     return tf.squeeze(pool, [2])
 
 
 def tempo_block(inputs, filters, kernel_size, is_training, config, padding="same", activation=tf.nn.relu, trainable=True):
 
-    conv = tf.compat.v1.layers.conv2d(inputs=inputs,
-                            filters=filters,
-                            kernel_size=kernel_size,
-                            padding=padding,
-                            activation=activation,
-                            trainable=trainable,
-                            kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
-    bn_conv = tf.compat.v1.layers.batch_normalization(conv, training=is_training, trainable=trainable)
-    pool = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv,
-                                   pool_size=[1, bn_conv.shape[2]],
-                                   strides=[1, bn_conv.shape[2]])
+    conv = tf.layers.conv2d(
+        inputs=inputs,
+        filters=filters,
+        kernel_size=kernel_size,
+        padding=padding,
+        activation=activation,
+        trainable=trainable,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+    )
+    bn_conv = tf.layers.batch_normalization(conv, training=is_training, trainable=trainable)
+    pool = tf.layers.max_pooling2d(inputs=bn_conv, pool_size=[1, bn_conv.shape[2]], strides=[1, bn_conv.shape[2]])
     return tf.squeeze(pool, [2])
 

--- a/src/models_midend.py
+++ b/src/models_midend.py
@@ -1,45 +1,52 @@
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 
 def dense_cnns(front_end_output, is_training, num_filt, config, trainable=True):
 
     # conv layer 1 - adapting dimensions
     front_end_pad = tf.pad(front_end_output, [[0, 0], [3, 3], [0, 0]], "CONSTANT")
-    conv1 = tf.compat.v1.layers.conv1d(inputs=front_end_pad,
-                             filters=num_filt,
-                             kernel_size=7,
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']),
-                             trainable=trainable)
+    conv1 = tf.layers.conv1d(
+        inputs=front_end_pad,
+        filters=num_filt,
+        kernel_size=7,
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+        trainable=trainable,
+    )
 
     if not trainable:
         conv1.trainable = False
 
-    bn_conv1 = tf.compat.v1.layers.batch_normalization(conv1, training=is_training, trainable=trainable)
+    bn_conv1 = tf.layers.batch_normalization(conv1, training=is_training, trainable=trainable)
 
     # conv layer 2 - residual connection
     bn_conv1_pad = tf.pad(bn_conv1, [[0, 0], [3, 3], [0, 0]], "CONSTANT")
-    conv2 = tf.compat.v1.layers.conv1d(inputs=bn_conv1_pad,
-                             filters=num_filt,
-                             kernel_size=7,
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']),
-                             trainable=trainable)
-    bn_conv2 = tf.compat.v1.layers.batch_normalization(conv2, training=is_training, trainable=trainable)
+    conv2 = tf.layers.conv1d(
+        inputs=bn_conv1_pad,
+        filters=num_filt,
+        kernel_size=7,
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+        trainable=trainable,
+    )
+    bn_conv2 = tf.layers.batch_normalization(conv2, training=is_training, trainable=trainable)
     res_conv2 = tf.add(conv2, bn_conv1)
 
     # conv layer 3 - residual connection
     bn_conv2_pad = tf.pad(res_conv2, [[0, 0], [3, 3], [0, 0]], "CONSTANT")
-    conv3 = tf.compat.v1.layers.conv1d(inputs=bn_conv2_pad,
-                             filters=num_filt,
-                             kernel_size=7,
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']),
-                             trainable=trainable)
-    bn_conv3 = tf.compat.v1.layers.batch_normalization(conv3, training=is_training, trainable=trainable)
+    conv3 = tf.layers.conv1d(
+        inputs=bn_conv2_pad,
+        filters=num_filt,
+        kernel_size=7,
+        padding="valid",
+        activation=tf.nn.relu,
+        kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
+        trainable=trainable,
+    )
+    bn_conv3 = tf.layers.batch_normalization(conv3, training=is_training, trainable=trainable)
     res_conv3 = tf.add(conv3, res_conv2)
 
     return [front_end_output, bn_conv1, res_conv2, res_conv3]

--- a/src/models_transfer_learning.py
+++ b/src/models_transfer_learning.py
@@ -286,7 +286,7 @@ def backend(feature_map, is_training, num_classes, output_units, config, type):
     if not num_classes:
         return dense_dropout, mean_pool, max_pool
     else:
-        initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config["seed"])
+        initializer = tf.initializers.variance_scaling(scale=2.0, seed=config["seed"])
         ld = tf.layers.dense(
             inputs=dense_dropout, activation=tf.nn.relu, units=num_classes, kernel_initializer=initializer
         )
@@ -370,7 +370,7 @@ def vgg(x, is_training, num_classes, config, num_filters=32):
     if not num_classes:
         return do_pool5
     else:
-        initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config["seed"])
+        initializer = tf.initializers.variance_scaling(scale=2.0, seed=config["seed"])
         return tf.layers.dense(
             inputs=do_pool5, activation=tf.nn.relu, units=num_classes, kernel_initializer=initializer
         )

--- a/src/models_transfer_learning.py
+++ b/src/models_transfer_learning.py
@@ -1,4 +1,5 @@
 import tensorflow as tf
+tf.disable_v2_behavior()
 from flip_gradient import flip_gradient
 # from musicnn import configuration as config
 
@@ -298,10 +299,11 @@ def backend(feature_map, is_training, num_classes, output_units, config, type):
     if not num_classes:
         return dense_dropout, mean_pool, max_pool
     else:
+        initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config['seed'])
         ld = tf.compat.v1.layers.dense(inputs=dense_dropout,
                                activation=tf.nn.relu,
                                units=num_classes,
-                               kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+                               kernel_initializer=initializer)
 
         return ld, mean_pool, max_pool
 
@@ -369,14 +371,15 @@ def vgg(x, is_training, num_classes, config, num_filters=32):
 
     flat_pool5 = tf.compat.v1.layers.flatten(pool5)
     do_pool5 = tf.compat.v1.layers.dropout(flat_pool5, rate=0.5, training=non_trainable)
-    
+
     if not num_classes:
         return do_pool5
     else:
+        initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config['seed'])
         return tf.compat.v1.layers.dense(inputs=do_pool5,
                                 activation=tf.nn.relu,
                                 units=num_classes,
-                                kernel_initializer=tf.contrib.layers.variance_scaling_initializer(seed=config['seed']))
+                                kernel_initializer=initializer)
 
 
 def define_vggish_slim(x, is_training, num_classes):

--- a/src/models_transfer_learning.py
+++ b/src/models_transfer_learning.py
@@ -286,9 +286,11 @@ def backend(feature_map, is_training, num_classes, output_units, config, type):
     if not num_classes:
         return dense_dropout, mean_pool, max_pool
     else:
-        initializer = tf.initializers.variance_scaling(scale=2.0, seed=config["seed"])
         ld = tf.layers.dense(
-            inputs=dense_dropout, activation=tf.nn.relu, units=num_classes, kernel_initializer=initializer
+            inputs=dense_dropout,
+            activation=tf.nn.relu,
+            units=num_classes,
+            kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
         )
 
         return ld, mean_pool, max_pool
@@ -370,9 +372,11 @@ def vgg(x, is_training, num_classes, config, num_filters=32):
     if not num_classes:
         return do_pool5
     else:
-        initializer = tf.initializers.variance_scaling(scale=2.0, seed=config["seed"])
         return tf.layers.dense(
-            inputs=do_pool5, activation=tf.nn.relu, units=num_classes, kernel_initializer=initializer
+            inputs=do_pool5,
+            activation=tf.nn.relu,
+            units=num_classes,
+            kernel_initializer=tf.initializers.variance_scaling(scale=2.0, seed=config["seed"]),
         )
 
 

--- a/src/models_transfer_learning.py
+++ b/src/models_transfer_learning.py
@@ -1,5 +1,5 @@
 import tensorflow as tf
-tf.disable_v2_behavior()
+tf.compat.v1.disable_v2_behavior()
 
 import tf_slim as slim
 from flip_gradient import flip_gradient

--- a/src/models_transfer_learning.py
+++ b/src/models_transfer_learning.py
@@ -1,5 +1,5 @@
-import tensorflow as tf
-tf.compat.v1.disable_v2_behavior()
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 import tf_slim as slim
 from flip_gradient import flip_gradient
@@ -7,7 +7,7 @@ from flip_gradient import flip_gradient
 # from musicnn import configuration as config
 
 # disabling deprecation warnings (caused by change from tensorflow 1.x to 2.x)
-#tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
+# tf.logging.set_verbosity(tf.logging.ERROR)
 
 
 def define_model(x, is_training, config):
@@ -118,7 +118,7 @@ def build_musicnn1d(x, is_training, num_classes, config, num_filt_frontend=1.6, 
 def frontend(x, is_training, yInput, num_filt, type):
 
     expand_input = tf.expand_dims(x, 3)
-    normalized_input = tf.compat.v1.layers.batch_normalization(expand_input, training=is_training, trainable=False)
+    normalized_input = tf.layers.batch_normalization(expand_input, training=is_training, trainable=False)
 
     if 'timbral' in type:
 
@@ -163,31 +163,21 @@ def frontend(x, is_training, yInput, num_filt, type):
 
 def timbral_block(inputs, filters, kernel_size, is_training, padding="valid", activation=tf.nn.relu):
 
-    conv = tf.compat.v1.layers.conv2d(inputs=inputs,
-                            filters=filters,
-                            kernel_size=kernel_size,
-                            padding=padding,
-                            activation=activation,
-                            trainable=False)
-    bn_conv = tf.compat.v1.layers.batch_normalization(conv, training=is_training, trainable=False)
-    pool = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv,
-                                   pool_size=[1, bn_conv.shape[2]],
-                                   strides=[1, bn_conv.shape[2]])
+    conv = tf.layers.conv2d(
+        inputs=inputs, filters=filters, kernel_size=kernel_size, padding=padding, activation=activation, trainable=False
+    )
+    bn_conv = tf.layers.batch_normalization(conv, training=is_training, trainable=False)
+    pool = tf.layers.max_pooling2d(inputs=bn_conv, pool_size=[1, bn_conv.shape[2]], strides=[1, bn_conv.shape[2]])
     return tf.squeeze(pool, [2])
 
 
 def tempo_block(inputs, filters, kernel_size, is_training, padding="same", activation=tf.nn.relu):
 
-    conv = tf.compat.v1.layers.conv2d(inputs=inputs,
-                            filters=filters,
-                            kernel_size=kernel_size,
-                            padding=padding,
-                            activation=activation,
-                            trainable=False)
-    bn_conv = tf.compat.v1.layers.batch_normalization(conv, training=is_training, trainable=False)
-    pool = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv,
-                                   pool_size=[1, bn_conv.shape[2]],
-                                   strides=[1, bn_conv.shape[2]])
+    conv = tf.layers.conv2d(
+        inputs=inputs, filters=filters, kernel_size=kernel_size, padding=padding, activation=activation, trainable=False
+    )
+    bn_conv = tf.layers.batch_normalization(conv, training=is_training, trainable=False)
+    pool = tf.layers.max_pooling2d(inputs=bn_conv, pool_size=[1, bn_conv.shape[2]], strides=[1, bn_conv.shape[2]])
     return tf.squeeze(pool, [2])
 
 
@@ -197,36 +187,42 @@ def midend(front_end_output, is_training, num_filt):
 
     # conv layer 1 - adapting dimensions
     front_end_pad = tf.pad(front_end_output, [[0, 0], [3, 3], [0, 0], [0, 0]], "CONSTANT")
-    conv1 = tf.compat.v1.layers.conv2d(inputs=front_end_pad,
-                             filters=num_filt,
-                             kernel_size=[7, front_end_pad.shape[2]],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             trainable=False)
-    bn_conv1 = tf.compat.v1.layers.batch_normalization(conv1, training=is_training, trainable=False)
+    conv1 = tf.layers.conv2d(
+        inputs=front_end_pad,
+        filters=num_filt,
+        kernel_size=[7, front_end_pad.shape[2]],
+        padding="valid",
+        activation=tf.nn.relu,
+        trainable=False,
+    )
+    bn_conv1 = tf.layers.batch_normalization(conv1, training=is_training, trainable=False)
     bn_conv1_t = tf.transpose(bn_conv1, [0, 1, 3, 2])
 
     # conv layer 2 - residual connection
     bn_conv1_pad = tf.pad(bn_conv1_t, [[0, 0], [3, 3], [0, 0], [0, 0]], "CONSTANT")
-    conv2 = tf.compat.v1.layers.conv2d(inputs=bn_conv1_pad,
-                             filters=num_filt,
-                             kernel_size=[7, bn_conv1_pad.shape[2]],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             trainable=False)
-    bn_conv2 = tf.compat.v1.layers.batch_normalization(conv2, training=is_training, trainable=False)
+    conv2 = tf.layers.conv2d(
+        inputs=bn_conv1_pad,
+        filters=num_filt,
+        kernel_size=[7, bn_conv1_pad.shape[2]],
+        padding="valid",
+        activation=tf.nn.relu,
+        trainable=False,
+    )
+    bn_conv2 = tf.layers.batch_normalization(conv2, training=is_training, trainable=False)
     conv2 = tf.transpose(bn_conv2, [0, 1, 3, 2])
     res_conv2 = tf.add(conv2, bn_conv1_t)
 
     # conv layer 3 - residual connection
     bn_conv2_pad = tf.pad(res_conv2, [[0, 0], [3, 3], [0, 0], [0, 0]], "CONSTANT")
-    conv3 = tf.compat.v1.layers.conv2d(inputs=bn_conv2_pad,
-                             filters=num_filt,
-                             kernel_size=[7, bn_conv2_pad.shape[2]],
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             trainable=False)
-    bn_conv3 = tf.compat.v1.layers.batch_normalization(conv3, training=is_training, trainable=False)
+    conv3 = tf.layers.conv2d(
+        inputs=bn_conv2_pad,
+        filters=num_filt,
+        kernel_size=[7, bn_conv2_pad.shape[2]],
+        padding="valid",
+        activation=tf.nn.relu,
+        trainable=False,
+    )
+    bn_conv3 = tf.layers.batch_normalization(conv3, training=is_training, trainable=False)
     conv3 = tf.transpose(bn_conv3, [0, 1, 3, 2])
     res_conv3 = tf.add(conv3, res_conv2)
 
@@ -239,36 +235,27 @@ def midend1d(front_end_output, is_training, num_filt):
 
     # conv layer 1 - adapting dimensions
     front_end_pad = tf.pad(front_end_output, [[0, 0], [3, 3], [0, 0]], "CONSTANT")
-    conv1 = tf.compat.v1.layers.conv1d(inputs=front_end_pad,
-                             filters=num_filt,
-                             kernel_size=7,
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             trainable=False)
-    bn_conv1 = tf.compat.v1.layers.batch_normalization(conv1, training=is_training, trainable=False)
+    conv1 = tf.layers.conv1d(
+        inputs=front_end_pad, filters=num_filt, kernel_size=7, padding="valid", activation=tf.nn.relu, trainable=False
+    )
+    bn_conv1 = tf.layers.batch_normalization(conv1, training=is_training, trainable=False)
     # bn_conv1_t = tf.transpose(bn_conv1, [0, 1, 3, 2])
 
     # conv layer 2 - residual connection
     bn_conv1_pad = tf.pad(bn_conv1, [[0, 0], [3, 3], [0, 0]], "CONSTANT")
-    conv2 = tf.compat.v1.layers.conv1d(inputs=bn_conv1_pad,
-                             filters=num_filt,
-                             kernel_size=7,
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             trainable=False)
-    bn_conv2 = tf.compat.v1.layers.batch_normalization(conv2, training=is_training, trainable=False)
+    conv2 = tf.layers.conv1d(
+        inputs=bn_conv1_pad, filters=num_filt, kernel_size=7, padding="valid", activation=tf.nn.relu, trainable=False
+    )
+    bn_conv2 = tf.layers.batch_normalization(conv2, training=is_training, trainable=False)
     # conv2 = tf.transpose(bn_conv2, [0, 1, 3, 2])
     res_conv2 = tf.add(conv2, bn_conv1)
 
     # conv layer 3 - residual connection
     bn_conv2_pad = tf.pad(res_conv2, [[0, 0], [3, 3], [0, 0]], "CONSTANT")
-    conv3 = tf.compat.v1.layers.conv1d(inputs=bn_conv2_pad,
-                             filters=num_filt,
-                             kernel_size=7,
-                             padding="valid",
-                             activation=tf.nn.relu,
-                             trainable=False)
-    bn_conv3 = tf.compat.v1.layers.batch_normalization(conv3, training=is_training, trainable=False)
+    conv3 = tf.layers.conv1d(
+        inputs=bn_conv2_pad, filters=num_filt, kernel_size=7, padding="valid", activation=tf.nn.relu, trainable=False
+    )
+    bn_conv3 = tf.layers.batch_normalization(conv3, training=is_training, trainable=False)
     # conv3 = tf.transpose(bn_conv3, [0, 1, 3, 2])
     res_conv3 = tf.add(conv3, res_conv2)
 
@@ -288,25 +275,21 @@ def backend(feature_map, is_training, num_classes, output_units, config, type):
     tmp_pool = tf.concat([max_pool, mean_pool], n_tmp_pool)
 
     # penultimate dense layer
-    flat_pool = tf.compat.v1.layers.flatten(tmp_pool)
-    flat_pool = tf.compat.v1.layers.batch_normalization(flat_pool, training=False, trainable=False)
-    flat_pool_dropout = tf.compat.v1.layers.dropout(flat_pool, rate=0.5, training=False)
-    dense = tf.compat.v1.layers.dense(inputs=flat_pool_dropout,
-                            units=output_units,
-                            activation=tf.nn.relu,
-                            trainable=False)
-    bn_dense = tf.compat.v1.layers.batch_normalization(dense, training=False, trainable=False)
-    dense_dropout = tf.compat.v1.layers.dropout(bn_dense, rate=0.5, training=False)
+    flat_pool = tf.layers.flatten(tmp_pool)
+    flat_pool = tf.layers.batch_normalization(flat_pool, training=False, trainable=False)
+    flat_pool_dropout = tf.layers.dropout(flat_pool, rate=0.5, training=False)
+    dense = tf.layers.dense(inputs=flat_pool_dropout, units=output_units, activation=tf.nn.relu, trainable=False)
+    bn_dense = tf.layers.batch_normalization(dense, training=False, trainable=False)
+    dense_dropout = tf.layers.dropout(bn_dense, rate=0.5, training=False)
 
     # output dense layer
     if not num_classes:
         return dense_dropout, mean_pool, max_pool
     else:
-        initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config['seed'])
-        ld = tf.compat.v1.layers.dense(inputs=dense_dropout,
-                               activation=tf.nn.relu,
-                               units=num_classes,
-                               kernel_initializer=initializer)
+        initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config["seed"])
+        ld = tf.layers.dense(
+            inputs=dense_dropout, activation=tf.nn.relu, units=num_classes, kernel_initializer=initializer
+        )
 
         return ld, mean_pool, max_pool
 
@@ -315,73 +298,82 @@ def vgg(x, is_training, num_classes, config, num_filters=32):
     non_trainable = False
 
     input_layer = tf.expand_dims(x, 3)
-    bn_input = tf.compat.v1.layers.batch_normalization(input_layer, training=non_trainable, trainable=non_trainable)
+    bn_input = tf.layers.batch_normalization(input_layer, training=non_trainable, trainable=non_trainable)
 
-    conv1 = tf.compat.v1.layers.conv2d(inputs=bn_input,
-                             filters=num_filters,
-                             kernel_size=[3, 3],
-                             padding='same',
-                             activation=tf.nn.relu,
-                             name='1CNN',
-                             trainable=non_trainable)
-    bn_conv1 = tf.compat.v1.layers.batch_normalization(conv1, training=non_trainable, trainable=non_trainable)
-    pool1 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv1, pool_size=[4, 1], strides=[2, 2])
+    conv1 = tf.layers.conv2d(
+        inputs=bn_input,
+        filters=num_filters,
+        kernel_size=[3, 3],
+        padding="same",
+        activation=tf.nn.relu,
+        name="1CNN",
+        trainable=non_trainable,
+    )
+    bn_conv1 = tf.layers.batch_normalization(conv1, training=non_trainable, trainable=non_trainable)
+    pool1 = tf.layers.max_pooling2d(inputs=bn_conv1, pool_size=[4, 1], strides=[2, 2])
 
-    do_pool1 = tf.compat.v1.layers.dropout(pool1, rate=0.25, training=non_trainable)
-    conv2 = tf.compat.v1.layers.conv2d(inputs=do_pool1,
-                             filters=num_filters,
-                             kernel_size=[3, 3],
-                             padding='same',
-                             activation=tf.nn.relu,
-                             name='2CNN',
-                             trainable=non_trainable)
-    bn_conv2 = tf.compat.v1.layers.batch_normalization(conv2, training=non_trainable, trainable=non_trainable)
-    pool2 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv2, pool_size=[2, 2], strides=[2, 2])
+    do_pool1 = tf.layers.dropout(pool1, rate=0.25, training=non_trainable)
+    conv2 = tf.layers.conv2d(
+        inputs=do_pool1,
+        filters=num_filters,
+        kernel_size=[3, 3],
+        padding="same",
+        activation=tf.nn.relu,
+        name="2CNN",
+        trainable=non_trainable,
+    )
+    bn_conv2 = tf.layers.batch_normalization(conv2, training=non_trainable, trainable=non_trainable)
+    pool2 = tf.layers.max_pooling2d(inputs=bn_conv2, pool_size=[2, 2], strides=[2, 2])
 
-    do_pool2 = tf.compat.v1.layers.dropout(pool2, rate=0.25, training=non_trainable)
-    conv3 = tf.compat.v1.layers.conv2d(inputs=do_pool2,
-                             filters=num_filters,
-                             kernel_size=[3, 3],
-                             padding='same',
-                             activation=tf.nn.relu,
-                             name='3CNN',
-                             trainable=non_trainable)
-    bn_conv3 = tf.compat.v1.layers.batch_normalization(conv3, training=non_trainable, trainable=non_trainable)
-    pool3 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv3, pool_size=[2, 2], strides=[2, 2])
+    do_pool2 = tf.layers.dropout(pool2, rate=0.25, training=non_trainable)
+    conv3 = tf.layers.conv2d(
+        inputs=do_pool2,
+        filters=num_filters,
+        kernel_size=[3, 3],
+        padding="same",
+        activation=tf.nn.relu,
+        name="3CNN",
+        trainable=non_trainable,
+    )
+    bn_conv3 = tf.layers.batch_normalization(conv3, training=non_trainable, trainable=non_trainable)
+    pool3 = tf.layers.max_pooling2d(inputs=bn_conv3, pool_size=[2, 2], strides=[2, 2])
 
-    do_pool3 = tf.compat.v1.layers.dropout(pool3, rate=0.25, training=non_trainable)
-    conv4 = tf.compat.v1.layers.conv2d(inputs=do_pool3,
-                             filters=num_filters,
-                             kernel_size=[3, 3],
-                             padding='same',
-                             activation=tf.nn.relu,
-                             name='4CNN',
-                             trainable=non_trainable)
-    bn_conv4 = tf.compat.v1.layers.batch_normalization(conv4, training=non_trainable, trainable=non_trainable)
-    pool4 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv4, pool_size=[2, 2], strides=[2, 2])
+    do_pool3 = tf.layers.dropout(pool3, rate=0.25, training=non_trainable)
+    conv4 = tf.layers.conv2d(
+        inputs=do_pool3,
+        filters=num_filters,
+        kernel_size=[3, 3],
+        padding="same",
+        activation=tf.nn.relu,
+        name="4CNN",
+        trainable=non_trainable,
+    )
+    bn_conv4 = tf.layers.batch_normalization(conv4, training=non_trainable, trainable=non_trainable)
+    pool4 = tf.layers.max_pooling2d(inputs=bn_conv4, pool_size=[2, 2], strides=[2, 2])
 
-    do_pool4 = tf.compat.v1.layers.dropout(pool4, rate=0.25, training=non_trainable)
-    conv5 = tf.compat.v1.layers.conv2d(inputs=do_pool4,
-                             filters=num_filters,
-                             kernel_size=[3, 3],
-                             padding='same',
-                             activation=tf.nn.relu,
-                             name='5CNN',
-                             trainable=non_trainable)
-    bn_conv5 = tf.compat.v1.layers.batch_normalization(conv5, training=is_training, trainable=non_trainable)
-    pool5 = tf.compat.v1.layers.max_pooling2d(inputs=bn_conv5, pool_size=[4, 4], strides=[4, 4])
+    do_pool4 = tf.layers.dropout(pool4, rate=0.25, training=non_trainable)
+    conv5 = tf.layers.conv2d(
+        inputs=do_pool4,
+        filters=num_filters,
+        kernel_size=[3, 3],
+        padding="same",
+        activation=tf.nn.relu,
+        name="5CNN",
+        trainable=non_trainable,
+    )
+    bn_conv5 = tf.layers.batch_normalization(conv5, training=is_training, trainable=non_trainable)
+    pool5 = tf.layers.max_pooling2d(inputs=bn_conv5, pool_size=[4, 4], strides=[4, 4])
 
-    flat_pool5 = tf.compat.v1.layers.flatten(pool5)
-    do_pool5 = tf.compat.v1.layers.dropout(flat_pool5, rate=0.5, training=non_trainable)
+    flat_pool5 = tf.layers.flatten(pool5)
+    do_pool5 = tf.layers.dropout(flat_pool5, rate=0.5, training=non_trainable)
 
     if not num_classes:
         return do_pool5
     else:
-        initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config['seed'])
-        return tf.compat.v1.layers.dense(inputs=do_pool5,
-                                activation=tf.nn.relu,
-                                units=num_classes,
-                                kernel_initializer=initializer)
+        initializer = tf.keras.initializers.VarianceScaling(scale=2.0, seed=config["seed"])
+        return tf.layers.dense(
+            inputs=do_pool5, activation=tf.nn.relu, units=num_classes, kernel_initializer=initializer
+        )
 
 
 def define_vggish_slim(features_tensor, is_training, num_classes):

--- a/src/predict.py
+++ b/src/predict.py
@@ -1,16 +1,16 @@
 import argparse
-import os
 import json
+import os
+
+import numpy as np
 import pescador
 import shared
-import train
-import numpy as np
-import tensorflow as tf
-from tqdm import tqdm
-import yaml
-from argparse import Namespace
-from data_loaders import data_gen_standard as data_gen
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
+import train
+from data_loaders import data_gen_standard as data_gen
+from tqdm import tqdm
 
 TEST_BATCH_SIZE = 64
 

--- a/src/train.py
+++ b/src/train.py
@@ -6,7 +6,8 @@ import time
 import yaml
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 import pescador
 
 import shared
@@ -25,7 +26,7 @@ def write_summary(value, tag, step, writer):
     writer.add_summary(summary, step)
 
 def tf_define_model_and_cost(config):
-        return model_and_cost(config, tf.compat.v1.placeholder(tf.bool))
+        return model_and_cost(config, tf.placeholder(tf.bool))
 
 def tf_define_model_and_cost_freeze(config):
         return model_and_cost(config, False)
@@ -33,8 +34,8 @@ def tf_define_model_and_cost_freeze(config):
 def model_and_cost(config, is_train):
     # tensorflow: define the model
     with tf.name_scope('model'):
-        x = tf.compat.v1.placeholder(tf.float32, [None, config['xInput'], config['yInput']])
-        y_ = tf.compat.v1.placeholder(tf.float32, [None, config['num_classes_dataset']])
+        x = tf.placeholder(tf.float32, [None, config['xInput'], config['yInput']])
+        y_ = tf.placeholder(tf.float32, [None, config['num_classes_dataset']])
 
         # choose between transfer learning or fully trainable models
         if config['load_model'] is not None:
@@ -78,8 +79,8 @@ def model_and_cost(config, is_train):
 
             cost = t_cost + d_cost
 
-            acc_task = tf.metrics.accuracy(y_, tf.compat.v1.round(normalized_y))
-            acc_discriminator = tf.metrics.accuracy(d_, tf.compat.v1.round(normalized_d))
+            acc_task = tf.metrics.accuracy(y_, tf.round(normalized_y))
+            acc_discriminator = tf.metrics.accuracy(d_, tf.round(normalized_d))
 
     # print all trainable variables, for debugging
     model_vars = [v for v in tf.global_variables()]
@@ -250,13 +251,13 @@ if __name__ == '__main__':
     if config['load_model'] is not None: # restore model weights from previously saved model
         if config['mode'] == 'adversarial_type_a':
             # Skip the layers we are going to train: 2 tasks X 2 layers X (kernel + bias) = 8
-            saver = tf.compat.v1.train.Saver(var_list=model_vars[:-8])
+            saver = tf.train.Saver(var_list=model_vars[:-8])
         elif config['mode'] == 'adversarial' or config['mode'] == 'adversarial_type_b':
             # Skip the layers we are going to train: 1 task X 3 layers X (kernel + bias) = 6
-            saver = tf.compat.v1.train.Saver(var_list=model_vars[:-6])
+            saver = tf.train.Saver(var_list=model_vars[:-6])
         else:
             # Skip the layers we are going to train: 1 task X 2 layers X (kernel + bias) = 4
-            saver = tf.compat.v1.train.Saver(var_list=model_vars[:-4])
+            saver = tf.train.Saver(var_list=model_vars[:-4])
         saver.restore(sess, config['load_model'])  # end with /!
         print('Pre-trained model loaded!')
 
@@ -264,7 +265,7 @@ if __name__ == '__main__':
 
     # After restoring make it aware of the rest of the variables
     # saver.var_list = model_vars
-    saver = tf.compat.v1.train.Saver()
+    saver = tf.train.Saver()
 
     # writing headers of the train_log.tsv
     fy = open(model_folder + 'train_log.tsv', 'a')


### PR DESCRIPTION
This PR removes `tf.contrib` from the codebase to make it possible to use tensorflow 2.

Changes to note:
1) introduce [tf-slim](https://github.com/google-research/tf-slim) for `vggish`. This model definition is now more in line with the original implementation in https://github.com/tensorflow/models/blob/master/research/audioset/vggish/vggish_slim.py
2) Switch from [contrib.layers.variance_scaling_initializer](https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/contrib/layers/variance_scaling_initializer) to [tf.compat.v1.keras.initializers.VarianceScaling](https://www.tensorflow.org/api_docs/python/tf/compat/v1/keras/initializers/VarianceScaling). I tried to match the initializers behaviour and adapted the to the best of my knowledge.
EDIT: We finally settled for `tensorflow.compat.v1.initializers.variance_scaling` since `keras.initializers.VarianceScaling` gave different random numbers.
3) Rely on `import tensorflow.compat.v1 as tf` and `tf.disable_v2_behavior()` for now. If we want to fully migrate we can move individual functions to the new API.
4) Greatly simplify `requirements.txt` and allow tensorflow 2