### PR TITLE
fix compatibility for numpy 1.16 in feature_ol3.py

### DIFF
--- a/src/feature_ol3.py
+++ b/src/feature_ol3.py
@@ -56,7 +56,7 @@ def feature_ol3(audio_file):
         melbands = 10. * np.log10(melbands)
         melbands = melbands - np.max(melbands)
         melbands = np.clip(melbands, -DRANGE, None)
-        batch = np.expand_dims(melbands, (0, 3))
+        batch = np.expand_dims(np.expand_dims(melbands, axis=0), axis=3)
 
         pool.set(INPUT, batch)
         embeddings.append(tfp(pool)[OUTPUT].squeeze())


### PR DESCRIPTION
older versions of numpy don't support tuples for the axis argument