### PR TITLE
Fix bug in the validation of models based on embeddings

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -56,7 +56,7 @@ def get_lowlevel_descriptors_groundtruth(config, id2audio_repr_path, orig_ids):
 
 def prediction(config, experiment_folder, id2audio_repr_path, id2gt, ids):
     # pescador: define (finite, batched & parallel) streamer
-    pack = [config, 'overlap_sampling', config['n_frames'], False, DATA_FOLDER]
+    pack = [config, 'overlap_sampling', config['xInput'], False, DATA_FOLDER]
     streams = [pescador.Streamer(data_gen, id, id2audio_repr_path[id], id2gt[id], pack) for id in ids]
     mux_stream = pescador.ChainMux(streams, mode='exhaustive')
     batch_streamer = pescador.Streamer(pescador.buffer_stream, mux_stream, buffer_size=TEST_BATCH_SIZE, partial=True)
@@ -152,6 +152,11 @@ if __name__ == '__main__':
         if task == 'alterations':
             config['task'] = 'alterations'
             config['alteration'] = alteration
+
+        if 'melspectrogram' in config['audio_rep']['type']:
+            config['xInput'] = config['n_frames']
+        elif config['audio_rep']['type'] == 'embeddings':
+            config['xInput'] = 1
 
         # load ground truth
         print('groundtruth file: {}'.format(FILE_GROUND_TRUTH_TEST))

--- a/src/predict.py
+++ b/src/predict.py
@@ -71,11 +71,16 @@ if __name__ == '__main__':
         config = json.load(open(os.path.join(experiment_folder, 'config.json')))
         config['mode'] = 'regular'
 
+        if 'melspectrogram' in config['audio_rep']['type']:
+            config['xInput'] = config['n_frames']
+        elif config['audio_rep']['type'] == 'embeddings':
+            config['xInput'] = 1
+
         print('Experiment: ' + str(model))
         print('\n' + str(config))
 
         # pescador: define (finite, batched & parallel) streamer
-        pack = [config, 'overlap_sampling', config['n_frames'], False]
+        pack = [config, 'overlap_sampling', config['xInput'], False]
         streams = [pescador.Streamer(data_gen, id, id2audio_repr_path[id], [0] * config['num_classes_dataset'], pack) for id in ids]
         mux_stream = pescador.ChainMux(streams, mode='exhaustive')
         batch_streamer = pescador.Streamer(pescador.buffer_stream, mux_stream, buffer_size=TEST_BATCH_SIZE, partial=True)


### PR DESCRIPTION
The data loaders used for validation were using the parameter `number_of_frames` as the hop size between adjacent patches.
This is only correct for spectrogram-based models.
For embedding-based models the hop size should be 1, as every column in the embedding
matrix corresponds to `number_of_frames` timestamps (1 to 3 seconds depending on the model).
This fix sets up a variable `xInput` with the correct hop size depending on the case just as in the train script.