### PR TITLE
Make compute_auc a bit more flexible for multilabel problems

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ mtgdb-models ]
+    branches: [ * ]
   pull_request:
-    branches: [ mtgdb-models ]
+    branches: [ * ]
 
 jobs:
   build:

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8 pytest wheel
+          python -m pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ * ]
+    branches: [ mtgdb-models ]
   pull_request:
-    branches: [ * ]
+    branches: [ mtgdb-models ]
 
 jobs:
   build:

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ mtgdb-models, compute_auc ]
+    branches: [ mtgdb-models ]
   pull_request:
     branches: [ mtgdb-models ]
 

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -1,0 +1,41 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ mtgdb-models ]
+  pull_request:
+    branches: [ mtgdb-models ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ 3.7, 3.8, 3.9 ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          cd src
+          # This is a hack since we don't have a setup.py yet!
+          python -m pytest ../test

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8 ]
+        python-version: [ 3.7 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8 pytest
+          python -m pip install flake8 pytest wheel
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ mtgdb-models ]
+    branches: [ mtgdb-models, compute_auc ]
   pull_request:
     branches: [ mtgdb-models ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@ pescador~=2.0.2
 pyyaml
 scikit-image
 scikit-learn~=0.21.3  # also a dependency of librosa
-# scikit-learn seems to have a missing build dependency
-Cython; python_version == "3.8"
 scipy~=1.3.0  # also a dependency of librosa, scikit-image & scikit-learn
 tensorflow>=1.15.0,<3.0
 tf-slim

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ pescador~=2.0.2
 pyyaml
 scikit-image
 scikit-learn~=0.21.3  # also a dependency of librosa
+# scikit-learn seems to have a missing build dependency
+Cython; python_version == "3.8"
 scipy~=1.3.0  # also a dependency of librosa, scikit-image & scikit-learn
 tensorflow>=1.15.0,<3.0
 tf-slim

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -55,7 +55,7 @@ def prediction(config, experiment_folder, id2audio_repr_path, id2gt, ids):
 
     print('Predictions computed, now evaluating...')
     y_true, y_pred = shared.average_predictions(pred_array, id_array, ids, id2gt)
-    roc_auc, pr_auc = shared.auc_with_aggergated_predictions(y_true, y_pred)
+    roc_auc, pr_auc = shared.compute_auc(y_true, y_pred)
     acc = shared.compute_accuracy(y_true, y_pred)
 
     metrics = (roc_auc, pr_auc, acc)

--- a/src/models_transfer_learning.py
+++ b/src/models_transfer_learning.py
@@ -56,7 +56,7 @@ def define_model(x, is_training, config):
         return define_small_vggish_slim(x, is_training, num_classes)
 
     elif model == 'MSD_musicnn_disc':
-        return build_musicnn_disc(x, is_training, config)
+        raise NotImplementedError
 
     else:
         raise ValueError('Model not implemented!')

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -1,19 +1,21 @@
-import os
-from joblib import Parallel, delayed
-import json
 import argparse
-import numpy as np
-from pathlib import Path
-import yaml
+import json
+import os
 from argparse import Namespace
+from pathlib import Path
+
+import librosa
+import numpy as np
+import yaml
+from joblib import Parallel, delayed
 from tqdm import tqdm
 
+from feature_effnet_b0 import feature_effnet_b0
 from feature_melspectrogram_essentia import feature_melspectrogram_essentia
 from feature_melspectrogram_vggish import feature_melspectrogram_vggish
 from feature_ol3 import feature_ol3
 from feature_spleeter import feature_spleeter
 from feature_tempocnn import feature_tempocnn
-from feature_effnet_b0 import feature_effnet_b0
 
 config_file = Namespace(**yaml.load(open('config_file.yaml'), Loader=yaml.SafeLoader))
 

--- a/src/score_predictions.py
+++ b/src/score_predictions.py
@@ -55,7 +55,7 @@ def score_predictions(results_file, predictions_file):
     store_results(results_file, roc_auc, pr_auc, acc, accs, report)
 
 def get_metrics(y_true, y_pred, fold_gt, fold_pred, folds):
-    roc_auc, pr_auc = shared.auc_with_aggergated_predictions(y_true, y_pred)
+    roc_auc, pr_auc = shared.compute_auc(y_true, y_pred)
     acc = shared.compute_accuracy(y_true, y_pred)
 
     accs = []

--- a/src/shared.py
+++ b/src/shared.py
@@ -41,6 +41,9 @@ def load_id2path(index_file):
 
 
 def compute_auc(true, estimated):
+    """
+    Calculate macro PR-AUC and macro ROC-AUC using the default scikit-learn parameters.
+    """
     estimated = np.array(estimated)
     true = np.array(true)
 

--- a/src/shared.py
+++ b/src/shared.py
@@ -1,8 +1,11 @@
-import numpy as np
-from datetime import datetime
-from sklearn import metrics
 import warnings
-warnings.filterwarnings('ignore')
+from datetime import datetime
+
+import numpy as np
+from sklearn import metrics
+from sklearn.utils.multiclass import type_of_target
+
+warnings.filterwarnings("ignore")
 
 
 def get_epoch_time():
@@ -36,26 +39,18 @@ def load_id2path(index_file):
     return paths, id2path
 
 
-def auc_with_aggergated_predictions(y_true, y_pred):
-    print('now computing AUC..')
-    roc_auc, pr_auc = compute_auc(y_true, y_pred)
-    return np.mean(roc_auc), np.mean(pr_auc)
-
-
 def compute_auc(true, estimated):
-    pr_auc = []
-    roc_auc = []
-
     estimated = np.array(estimated)
     true = np.array(true)
 
-    for count in range(0, estimated.shape[1]):
-        try:
-            pr_auc.append(metrics.average_precision_score(true[:,count],estimated[:,count]))
-            roc_auc.append(metrics.roc_auc_score(true[:,count],estimated[:,count]))
-        except:
-            print('failed!')
+    if type_of_target(true) == "multiclass":
+        true = true.argmax(axis=1)
+
+    pr_auc = metrics.average_precision_score(true, estimated)
+    roc_auc = metrics.roc_auc_score(true, estimated)
+
     return roc_auc, pr_auc
+
 
 def sigmoid(x):
     return 1 / (1 + np.exp(-x))

--- a/src/shared.py
+++ b/src/shared.py
@@ -1,4 +1,5 @@
 import warnings
+from ast import literal_eval
 from datetime import datetime
 
 import numpy as np
@@ -22,8 +23,8 @@ def load_id2gt(gt_file):
     fgt = open(gt_file)
     id2gt = dict()
     for line in fgt.readlines():
-        id, gt = line.strip().split("\t") # id is string
-        id2gt[id] = eval(gt) # gt is array
+        id, gt = line.strip().split("\t")  # id is string
+        id2gt[id] = literal_eval(gt)  # gt is array
         ids.append(id)
     return ids, id2gt
 

--- a/test/test_shared.py
+++ b/test/test_shared.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+import shared
+
+
+def test_auc():
+    predicted = [
+        [0.2, 0.3, 0.5],
+        [0.2, 0.41, 0.39],
+        [0.2, 0.1, 0.7],
+        [0.8, 0.1, 0.1],
+        [0.4, 0.3, 0.3],
+    ]
+    groundtruth = [
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+        [1, 0, 0],
+        [0, 1, 0],
+    ]
+    roc_auc, pr_auc = shared.auc_with_aggergated_predictions(groundtruth, predicted)
+    np.testing.assert_allclose(roc_auc, 0.8611111)
+    np.testing.assert_allclose(pr_auc, 0.84444444)

--- a/test/test_shared.py
+++ b/test/test_shared.py
@@ -4,6 +4,9 @@ import shared
 
 
 def test_auc():
+    """
+    Test combined calculation of PR-AUC and ROC-AUC
+    """
     predicted = [
         [0.2, 0.3, 0.5],
         [0.2, 0.41, 0.39],
@@ -19,5 +22,7 @@ def test_auc():
         [0, 1, 0],
     ]
     roc_auc, pr_auc = shared.compute_auc(groundtruth, predicted)
+    # These values were computed using the previous implementation and match the
+    # results of scikit-learn when using default parameters
     np.testing.assert_allclose(roc_auc, 0.8611111)
     np.testing.assert_allclose(pr_auc, 0.84444444)

--- a/test/test_shared.py
+++ b/test/test_shared.py
@@ -18,6 +18,6 @@ def test_auc():
         [1, 0, 0],
         [0, 1, 0],
     ]
-    roc_auc, pr_auc = shared.auc_with_aggergated_predictions(groundtruth, predicted)
+    roc_auc, pr_auc = shared.compute_auc(groundtruth, predicted)
     np.testing.assert_allclose(roc_auc, 0.8611111)
     np.testing.assert_allclose(pr_auc, 0.84444444)


### PR DESCRIPTION
This is a small PR that adapts and simplifies compute_auc to prepare some changes needed when dealing with multi-label (instead of) multi-class data.

On the way I added & fixed a few minor things:

1. fix linting errors (add missing librosa import and remove reference to unimplemented function)
2. replace eval() with literal_eval()
3. add a standard python workflow that lints and tests for python 3.7 (python 3.8 fails to build scikit-learn dependency)