### PR TITLE
add new handling of one-hot encoded groundtruth data

### DIFF
--- a/src/shared.py
+++ b/src/shared.py
@@ -70,16 +70,21 @@ def compute_auc(true, estimated):
     """
     Calculate macro PR-AUC and macro ROC-AUC using the default scikit-learn parameters.
 
-    In case of multiclass data only ROC-AUC will be computed and PR AUC will be NaN.
+    Multiclass data is currently not supported and ROC-AUC & PR AUC will be NaN.
     """
     estimated = np.array(estimated)
     true = np.array(true)
 
     if type_of_groundtruth(true) == "multiclass-indicator":
         pr_auc = np.nan
+        # if we move to scikit-learn 0.22 we can calculate a roc_auc_score for
+        # multiclass data like this:
+        # estimated = estimated.argmax(axis=1)
+        # roc_auc = metrics.roc_auc_score(true, estimated, multi_class="ovr")
+        roc_auc = np.nan
     else:
         pr_auc = metrics.average_precision_score(true, estimated)
-    roc_auc = metrics.roc_auc_score(true, estimated, multi_class="ovr")
+        roc_auc = metrics.roc_auc_score(true, estimated)
     return roc_auc, pr_auc
 
 

--- a/src/shared.py
+++ b/src/shared.py
@@ -57,7 +57,10 @@ def type_of_groundtruth(y):
         sklearn.utils.multiclass.type_of_target
     """
     scikit_learn_type = type_of_target(y)
-    if scikit_learn_type == "multilabel-indicator" and np.count_nonzero(y) == y.shape[0]:
+    if (
+        scikit_learn_type == "multilabel-indicator"
+        and np.count_nonzero(y) == y.shape[0]
+    ):
         return "multiclass-indicator"
     else:
         return scikit_learn_type
@@ -66,16 +69,17 @@ def type_of_groundtruth(y):
 def compute_auc(true, estimated):
     """
     Calculate macro PR-AUC and macro ROC-AUC using the default scikit-learn parameters.
+
+    In case of multiclass data only ROC-AUC will be computed and PR AUC will be NaN.
     """
     estimated = np.array(estimated)
     true = np.array(true)
 
     if type_of_groundtruth(true) == "multiclass-indicator":
-        true = true.argmax(axis=1)
-
-    pr_auc = metrics.average_precision_score(true, estimated)
-    roc_auc = metrics.roc_auc_score(true, estimated)
-
+        pr_auc = np.nan
+    else:
+        pr_auc = metrics.average_precision_score(true, estimated)
+    roc_auc = metrics.roc_auc_score(true, estimated, multi_class="ovr")
     return roc_auc, pr_auc
 
 

--- a/src/shared.py
+++ b/src/shared.py
@@ -40,6 +40,29 @@ def load_id2path(index_file):
     return paths, id2path
 
 
+def type_of_groundtruth(y):
+    """
+    Get the type of groundtruth data by extending scikit learn functionality.
+
+    scikit-learn will detect one-hot encoded multiclass data as multilabl-indicator.
+    If this is the case this function returns "multiclass-indicator", which is
+    currently not used in scikit-learn, and the scikit-learn result otherwise.
+
+    Args:
+        y: numpy array with the groundtruth data
+
+    Returns:
+        target_type: string
+        Either "multiclass-indicator" or the result of
+        sklearn.utils.multiclass.type_of_target
+    """
+    scikit_learn_type = type_of_target(y)
+    if scikit_learn_type == "multilabel-indicator" and np.count_nonzero(y) == y.shape[0]:
+        return "multiclass-indicator"
+    else:
+        return scikit_learn_type
+
+
 def compute_auc(true, estimated):
     """
     Calculate macro PR-AUC and macro ROC-AUC using the default scikit-learn parameters.
@@ -47,7 +70,7 @@ def compute_auc(true, estimated):
     estimated = np.array(estimated)
     true = np.array(true)
 
-    if type_of_target(true) == "multiclass":
+    if type_of_groundtruth(true) == "multiclass-indicator":
         true = true.argmax(axis=1)
 
     pr_auc = metrics.average_precision_score(true, estimated)

--- a/test/test_shared.py
+++ b/test/test_shared.py
@@ -26,3 +26,13 @@ def test_auc():
     # results of scikit-learn when using default parameters
     np.testing.assert_allclose(roc_auc, 0.8611111)
     np.testing.assert_allclose(pr_auc, 0.84444444)
+
+
+def test_type_of_groundtruth():
+    assert shared.type_of_groundtruth([1, -1, -1, 1]) == "binary"
+    assert (
+        shared.type_of_groundtruth(np.array([[0, 1], [1, 1]])) == "multilabel-indicator"
+    )
+    assert (
+        shared.type_of_groundtruth(np.array([[0, 1], [1, 0]])) == "multiclass-indicator"
+    )

--- a/test/test_shared.py
+++ b/test/test_shared.py
@@ -16,15 +16,15 @@ def test_auc():
     ]
     groundtruth = [
         [1, 0, 0],
-        [0, 1, 0],
+        [0, 1, 1],
         [0, 0, 1],
         [1, 0, 0],
-        [0, 1, 0],
+        [1, 1, 0],
     ]
     roc_auc, pr_auc = shared.compute_auc(groundtruth, predicted)
-    # This value was computed using the previous implementation and match the
-    # results of scikit-learn when using default parameters
+    # These values were computed using default scikit-learn parameters
     np.testing.assert_allclose(roc_auc, 0.8611111)
+    np.testing.assert_allclose(pr_auc, 0.8444444)
 
 
 def test_type_of_groundtruth():

--- a/test/test_shared.py
+++ b/test/test_shared.py
@@ -22,10 +22,9 @@ def test_auc():
         [0, 1, 0],
     ]
     roc_auc, pr_auc = shared.compute_auc(groundtruth, predicted)
-    # These values were computed using the previous implementation and match the
+    # This value were computed using the previous implementation and match the
     # results of scikit-learn when using default parameters
     np.testing.assert_allclose(roc_auc, 0.8611111)
-    np.testing.assert_allclose(pr_auc, 0.84444444)
 
 
 def test_type_of_groundtruth():

--- a/test/test_shared.py
+++ b/test/test_shared.py
@@ -22,7 +22,7 @@ def test_auc():
         [0, 1, 0],
     ]
     roc_auc, pr_auc = shared.compute_auc(groundtruth, predicted)
-    # This value were computed using the previous implementation and match the
+    # This value was computed using the previous implementation and match the
     # results of scikit-learn when using default parameters
     np.testing.assert_allclose(roc_auc, 0.8611111)
 


### PR DESCRIPTION
before it was always detected as multilabel-indicator, which might have lead to unexpected behaviour