### PR TITLE
Fix averaged predictions misalignment

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -50,12 +50,12 @@ def prediction(config, experiment_folder, id2audio_repr_path, id2gt, ids):
     print(id_array.shape)
 
     print('Predictions computed, now evaluating...')
-    y_true, y_pred = shared.average_predictions(pred_array, id_array, ids, id2gt)
+    y_true, y_pred, healthy_ids = shared.average_predictions(pred_array, id_array, ids, id2gt)
     roc_auc, pr_auc = shared.compute_auc(y_true, y_pred)
     acc = shared.compute_accuracy(y_true, y_pred)
 
     metrics = (roc_auc, pr_auc, acc)
-    return y_pred, metrics
+    return y_pred, metrics, healthy_ids
 
 
 def store_results(results_file, predictions_file, models, ids, y_pred, metrics):
@@ -132,7 +132,7 @@ if __name__ == '__main__':
         print('# Test set size: ', len(ids))
 
         print('Performing regular evaluation')
-        y_pred, metrics = prediction(
+        y_pred, metrics, healthy_ids = prediction(
             config_train, experiment_folder, id2audio_repr_path, id2gt, ids)
 
         # store experimental results
@@ -141,4 +141,4 @@ if __name__ == '__main__':
         predictions_file = Path(
             exp_dir, f"predictions_{config_train['fold']}.json")
 
-        store_results(results_file, predictions_file, models, ids, y_pred, metrics)
+        store_results(results_file, predictions_file, models, healthy_ids, y_pred, metrics)

--- a/src/predict.py
+++ b/src/predict.py
@@ -13,20 +13,20 @@ from tqdm import tqdm
 
 TEST_BATCH_SIZE = 64
 
+
 def prediction(batch_dispatcher, tf_vars, array_cost, pred_array, id_array):
     [sess, normalized_y, cost, x, y_, is_train] = tf_vars
     for batch in tqdm(batch_dispatcher):
-        pred, cost_pred = sess.run([normalized_y, cost], feed_dict={x: batch['X'],
-                                                                    y_: batch['Y'],
-                                                                    is_train: False})
+        pred, _ = sess.run([normalized_y, cost], feed_dict={x: batch['X'],
+                                                            y_: batch['Y'],
+                                                            is_train: False})
 
-        if not array_cost:  # if array_cost is empty, is the first iteration
-            pred_array = pred
-            id_array = batch['ID']
-        else:
-            pred_array = np.concatenate((pred_array,pred), axis=0)
-            id_array = np.append(id_array,batch['ID'])
-        array_cost.append(cost_pred)
+        id_array.append(batch['ID'])
+        pred_array.append(pred)
+
+    id_array = np.hstack(id_array)
+    pred_array = np.vstack(pred_array)
+
     print('predictions', pred_array.shape)
     print('cost', np.mean(array_cost))
     return array_cost, pred_array, id_array

--- a/src/predict.py
+++ b/src/predict.py
@@ -13,20 +13,20 @@ from tqdm import tqdm
 
 TEST_BATCH_SIZE = 64
 
-
 def prediction(batch_dispatcher, tf_vars, array_cost, pred_array, id_array):
     [sess, normalized_y, cost, x, y_, is_train] = tf_vars
     for batch in tqdm(batch_dispatcher):
-        pred, _ = sess.run([normalized_y, cost], feed_dict={x: batch['X'],
-                                                            y_: batch['Y'],
-                                                            is_train: False})
+        pred, cost_pred = sess.run([normalized_y, cost], feed_dict={x: batch['X'],
+                                                                    y_: batch['Y'],
+                                                                    is_train: False})
 
-        id_array.append(batch['ID'])
-        pred_array.append(pred)
-
-    id_array = np.hstack(id_array)
-    pred_array = np.vstack(pred_array)
-
+        if not array_cost:  # if array_cost is empty, is the first iteration
+            pred_array = pred
+            id_array = batch['ID']
+        else:
+            pred_array = np.concatenate((pred_array,pred), axis=0)
+            id_array = np.append(id_array,batch['ID'])
+        array_cost.append(cost_pred)
     print('predictions', pred_array.shape)
     print('cost', np.mean(array_cost))
     return array_cost, pred_array, id_array

--- a/src/shared.py
+++ b/src/shared.py
@@ -103,6 +103,7 @@ def average_predictions(pred_array, id_array, ids, id2gt=None):
     print('Averaging predictions')
     y_pred = []
     y_true = []
+    healthy_ids = []
     for id in ids:
         try:
             avg = np.mean(pred_array[np.where(id_array == id)], axis=0)
@@ -120,11 +121,12 @@ def average_predictions(pred_array, id_array, ids, id2gt=None):
             y_pred.append(avg)
             if id2gt:
                 y_true.append(id2gt[id])
+                healthy_ids.append(id)
         except:
             print(id)
 
     if id2gt:
-        return y_true, y_pred
+        return y_true, y_pred, healthy_ids
     else:
         return y_pred
 


### PR DESCRIPTION
`average_predictions` has a capability to skip unhealthy ids containing NaNs or infs.
However right now there is no way to track which ids are skipped causing true/pred misalignment.

This is solved by returning a vector `healthy_ids` that is used to construct aligned true/pred arrays.